### PR TITLE
Extend `return_value_policy_pack` support to `py::cast()` and trampolines

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -810,14 +810,7 @@ public:
         }
         if (rvpp.policy == return_value_policy::take_ownership) {
             auto h = cast(std::move(*src), rvpp, parent);
-#if defined(__CUDACC__) || defined(__MINGW32__)
-            PYBIND11_WARNING_PUSH
-            PYBIND11_WARNING_DISABLE_GCC("-Wfree-nonheap-object")
-#endif
             delete src;
-#if defined(__CUDACC__) || defined(__MINGW32__)
-            PYBIND11_WARNING_POP
-#endif
             return h;
         }
         return cast(*src, rvpp, parent);

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -810,7 +810,14 @@ public:
         }
         if (rvpp.policy == return_value_policy::take_ownership) {
             auto h = cast(std::move(*src), rvpp, parent);
+#if defined(__CUDACC__) || defined(__MINGW32__)
+            PYBIND11_WARNING_PUSH
+            PYBIND11_WARNING_DISABLE_GCC("-Wfree-nonheap-object")
+#endif
             delete src;
+#if defined(__CUDACC__) || defined(__MINGW32__)
+            PYBIND11_WARNING_POP
+#endif
             return h;
         }
         return cast(*src, rvpp, parent);

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -3053,28 +3053,13 @@ function get_override(const T *this_ptr, const char *name) {
     return tinfo ? detail::get_type_override(this_ptr, tinfo, name) : function();
 }
 
-#define PYBIND11_OVERRIDE_IMPL(ret_type, cname, name, ...)                                        \
+#define PYBIND11_OVERRIDE_IMPL(override_call, ret_type, cname, name, ...)                         \
     do {                                                                                          \
         pybind11::gil_scoped_acquire gil;                                                         \
         pybind11::function override                                                               \
             = pybind11::get_override(static_cast<const cname *>(this), name);                     \
         if (override) {                                                                           \
-            auto o = override(__VA_ARGS__);                                                       \
-            if (pybind11::detail::cast_is_temporary_value_reference<ret_type>::value) {           \
-                static pybind11::detail::override_caster_t<ret_type> caster;                      \
-                return pybind11::detail::cast_ref<ret_type>(std::move(o), caster);                \
-            }                                                                                     \
-            return pybind11::detail::cast_safe<ret_type>(std::move(o));                           \
-        }                                                                                         \
-    } while (false)
-
-#define PYBIND11_OVERRIDE_IMPL_RVPP(ret_type, cname, name, ...)                                   \
-    do {                                                                                          \
-        pybind11::gil_scoped_acquire gil;                                                         \
-        pybind11::function override                                                               \
-            = pybind11::get_override(static_cast<const cname *>(this), name);                     \
-        if (override) {                                                                           \
-            auto o = override.call_with_policies(__VA_ARGS__);                                    \
+            auto o = override_call(__VA_ARGS__);                                                  \
             if (pybind11::detail::cast_is_temporary_value_reference<ret_type>::value) {           \
                 static pybind11::detail::override_caster_t<ret_type> caster;                      \
                 return pybind11::detail::cast_ref<ret_type>(std::move(o), caster);                \
@@ -3103,7 +3088,8 @@ function get_override(const T *this_ptr, const char *name) {
 \endrst */
 #define PYBIND11_OVERRIDE_NAME(ret_type, cname, name, fn, ...)                                    \
     do {                                                                                          \
-        PYBIND11_OVERRIDE_IMPL(PYBIND11_TYPE(ret_type), PYBIND11_TYPE(cname), name, __VA_ARGS__); \
+        PYBIND11_OVERRIDE_IMPL(                                                                   \
+            override, PYBIND11_TYPE(ret_type), PYBIND11_TYPE(cname), name, __VA_ARGS__);          \
         return cname::fn(__VA_ARGS__);                                                            \
     } while (false)
 
@@ -3113,7 +3099,8 @@ function get_override(const T *this_ptr, const char *name) {
 \endrst */
 #define PYBIND11_OVERRIDE_PURE_NAME(ret_type, cname, name, fn, ...)                               \
     do {                                                                                          \
-        PYBIND11_OVERRIDE_IMPL(PYBIND11_TYPE(ret_type), PYBIND11_TYPE(cname), name, __VA_ARGS__); \
+        PYBIND11_OVERRIDE_IMPL(                                                                   \
+            override, PYBIND11_TYPE(ret_type), PYBIND11_TYPE(cname), name, __VA_ARGS__);          \
         pybind11::pybind11_fail(                                                                  \
             "Tried to call pure virtual function \"" PYBIND11_STRINGIFY(cname) "::" name "\"");   \
     } while (false)
@@ -3127,15 +3114,21 @@ function get_override(const T *this_ptr, const char *name) {
 
 #define PYBIND11_OVERRIDE_NAME_RVPP(ret_type, cname, name, fn, ...)                               \
     do {                                                                                          \
-        PYBIND11_OVERRIDE_IMPL_RVPP(                                                              \
-            PYBIND11_TYPE(ret_type), PYBIND11_TYPE(cname), name, __VA_ARGS__);                    \
+        PYBIND11_OVERRIDE_IMPL(override.call_with_policies,                                       \
+                               PYBIND11_TYPE(ret_type),                                           \
+                               PYBIND11_TYPE(cname),                                              \
+                               name,                                                              \
+                               __VA_ARGS__);                                                      \
         return cname::fn(PYBIND11_STRIP_FIRST_ARG(__VA_ARGS__));                                  \
     } while (false)
 
 #define PYBIND11_OVERRIDE_PURE_NAME_RVPP(ret_type, cname, name, fn, ...)                          \
     do {                                                                                          \
-        PYBIND11_OVERRIDE_IMPL_RVPP(                                                              \
-            PYBIND11_TYPE(ret_type), PYBIND11_TYPE(cname), name, __VA_ARGS__);                    \
+        PYBIND11_OVERRIDE_IMPL(override.call_with_policies,                                       \
+                               PYBIND11_TYPE(ret_type),                                           \
+                               PYBIND11_TYPE(cname),                                              \
+                               name,                                                              \
+                               __VA_ARGS__);                                                      \
         pybind11::pybind11_fail(                                                                  \
             "Tried to call pure virtual function \"" PYBIND11_STRINGIFY(cname) "::" name "\"");   \
     } while (false)
@@ -3190,7 +3183,8 @@ inline function get_overload(const T *this_ptr, const char *name) {
 }
 
 #define PYBIND11_OVERLOAD_INT(ret_type, cname, name, ...)                                         \
-    PYBIND11_OVERRIDE_IMPL(PYBIND11_TYPE(ret_type), PYBIND11_TYPE(cname), name, __VA_ARGS__)
+    PYBIND11_OVERRIDE_IMPL(                                                                       \
+        override, PYBIND11_TYPE(ret_type), PYBIND11_TYPE(cname), name, __VA_ARGS__)
 #define PYBIND11_OVERLOAD_NAME(ret_type, cname, name, fn, ...)                                    \
     PYBIND11_OVERRIDE_NAME(PYBIND11_TYPE(ret_type), PYBIND11_TYPE(cname), name, fn, __VA_ARGS__)
 #define PYBIND11_OVERLOAD_PURE_NAME(ret_type, cname, name, fn, ...)                               \

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -3118,7 +3118,12 @@ function get_override(const T *this_ptr, const char *name) {
             "Tried to call pure virtual function \"" PYBIND11_STRINGIFY(cname) "::" name "\"");   \
     } while (false)
 
-#define PYBIND11_STRIP_FIRST_ARG(A, ...) __VA_ARGS__
+// https://stackoverflow.com/questions/5134523/msvc-doesnt-expand-va-args-correctly
+// Not using `#if defined(_MSC_VER)` here to have only one implementation to test and debug.
+#define PYBIND11_PP_EXPAND(x) x
+#define PYBIND11_STRIP_FIRST_ARG_IMPL(A, ...) __VA_ARGS__
+#define PYBIND11_STRIP_FIRST_ARG(...)                                                             \
+    PYBIND11_PP_EXPAND(PYBIND11_STRIP_FIRST_ARG_IMPL(__VA_ARGS__))
 
 #define PYBIND11_OVERRIDE_NAME_RVPP(ret_type, cname, name, fn, ...)                               \
     do {                                                                                          \

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -3093,18 +3093,6 @@ function get_override(const T *this_ptr, const char *name) {
         return cname::fn(__VA_ARGS__);                                                            \
     } while (false)
 
-/** \rst
-    Macro for pure virtual functions, this function is identical to
-    :c:macro:`PYBIND11_OVERRIDE_NAME`, except that it throws if no override can be found.
-\endrst */
-#define PYBIND11_OVERRIDE_PURE_NAME(ret_type, cname, name, fn, ...)                               \
-    do {                                                                                          \
-        PYBIND11_OVERRIDE_IMPL(                                                                   \
-            override, PYBIND11_TYPE(ret_type), PYBIND11_TYPE(cname), name, __VA_ARGS__);          \
-        pybind11::pybind11_fail(                                                                  \
-            "Tried to call pure virtual function \"" PYBIND11_STRINGIFY(cname) "::" name "\"");   \
-    } while (false)
-
 // https://stackoverflow.com/questions/5134523/msvc-doesnt-expand-va-args-correctly
 // Not using `#if defined(_MSC_VER)` here to have only one implementation to test and debug.
 #define PYBIND11_PP_EXPAND(x) x
@@ -3122,16 +3110,24 @@ function get_override(const T *this_ptr, const char *name) {
         return cname::fn(PYBIND11_STRIP_FIRST_ARG(__VA_ARGS__));                                  \
     } while (false)
 
-#define PYBIND11_OVERRIDE_PURE_NAME_RVPP(ret_type, cname, name, fn, ...)                          \
+#define PYBIND11_OVERRIDE_PURE_NAME_IMPL(override_call, ret_type, cname, name, fn, ...)           \
     do {                                                                                          \
-        PYBIND11_OVERRIDE_IMPL(override.call_with_policies,                                       \
-                               PYBIND11_TYPE(ret_type),                                           \
-                               PYBIND11_TYPE(cname),                                              \
-                               name,                                                              \
-                               __VA_ARGS__);                                                      \
+        PYBIND11_OVERRIDE_IMPL(                                                                   \
+            override_call, PYBIND11_TYPE(ret_type), PYBIND11_TYPE(cname), name, __VA_ARGS__);     \
         pybind11::pybind11_fail(                                                                  \
             "Tried to call pure virtual function \"" PYBIND11_STRINGIFY(cname) "::" name "\"");   \
     } while (false)
+
+/** \rst
+    Macro for pure virtual functions, this function is identical to
+    :c:macro:`PYBIND11_OVERRIDE_NAME`, except that it throws if no override can be found.
+\endrst */
+#define PYBIND11_OVERRIDE_PURE_NAME(ret_type, cname, name, fn, ...)                               \
+    PYBIND11_OVERRIDE_PURE_NAME_IMPL(override, ret_type, cname, name, fn, __VA_ARGS__)
+
+#define PYBIND11_OVERRIDE_PURE_NAME_RVPP(ret_type, cname, name, fn, ...)                          \
+    PYBIND11_OVERRIDE_PURE_NAME_IMPL(                                                             \
+        override.call_with_policies, ret_type, cname, name, fn, __VA_ARGS__)
 
 /** \rst
     Macro to populate the virtual method in the trampoline class. This macro tries to look up the

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -3068,13 +3068,13 @@ function get_override(const T *this_ptr, const char *name) {
         }                                                                                         \
     } while (false)
 
-#define PYBIND11_OVERRIDE_IMPL_RVPP(ret_type, cname, name, rvpp, ...)                             \
+#define PYBIND11_OVERRIDE_IMPL_RVPP(ret_type, cname, name, ...)                                   \
     do {                                                                                          \
         pybind11::gil_scoped_acquire gil;                                                         \
         pybind11::function override                                                               \
             = pybind11::get_override(static_cast<const cname *>(this), name);                     \
         if (override) {                                                                           \
-            auto o = override.call_with_policies(rvpp __VA_OPT__(, ) __VA_ARGS__);                \
+            auto o = override.call_with_policies(__VA_ARGS__);                                    \
             if (pybind11::detail::cast_is_temporary_value_reference<ret_type>::value) {           \
                 static pybind11::detail::override_caster_t<ret_type> caster;                      \
                 return pybind11::detail::cast_ref<ret_type>(std::move(o), caster);                \
@@ -3118,17 +3118,19 @@ function get_override(const T *this_ptr, const char *name) {
             "Tried to call pure virtual function \"" PYBIND11_STRINGIFY(cname) "::" name "\"");   \
     } while (false)
 
-#define PYBIND11_OVERRIDE_NAME_RVPP(ret_type, cname, name, fn, rvpp, ...)                         \
+#define PYBIND11_STRIP_FIRST_ARG(A, ...) __VA_ARGS__
+
+#define PYBIND11_OVERRIDE_NAME_RVPP(ret_type, cname, name, fn, ...)                               \
     do {                                                                                          \
         PYBIND11_OVERRIDE_IMPL_RVPP(                                                              \
-            PYBIND11_TYPE(ret_type), PYBIND11_TYPE(cname), name, rvpp, __VA_ARGS__);              \
-        return cname::fn(__VA_ARGS__);                                                            \
+            PYBIND11_TYPE(ret_type), PYBIND11_TYPE(cname), name, __VA_ARGS__);                    \
+        return cname::fn(PYBIND11_STRIP_FIRST_ARG(__VA_ARGS__));                                  \
     } while (false)
 
-#define PYBIND11_OVERRIDE_PURE_NAME_RVPP(ret_type, cname, name, fn, rvpp, ...)                    \
+#define PYBIND11_OVERRIDE_PURE_NAME_RVPP(ret_type, cname, name, fn, ...)                          \
     do {                                                                                          \
         PYBIND11_OVERRIDE_IMPL_RVPP(                                                              \
-            PYBIND11_TYPE(ret_type), PYBIND11_TYPE(cname), name, rvpp, __VA_ARGS__);              \
+            PYBIND11_TYPE(ret_type), PYBIND11_TYPE(cname), name, __VA_ARGS__);                    \
         pybind11::pybind11_fail(                                                                  \
             "Tried to call pure virtual function \"" PYBIND11_STRINGIFY(cname) "::" name "\"");   \
     } while (false)

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -3118,6 +3118,21 @@ function get_override(const T *this_ptr, const char *name) {
             "Tried to call pure virtual function \"" PYBIND11_STRINGIFY(cname) "::" name "\"");   \
     } while (false)
 
+#define PYBIND11_OVERRIDE_NAME_RVPP(ret_type, cname, name, fn, rvpp, ...)                         \
+    do {                                                                                          \
+        PYBIND11_OVERRIDE_IMPL_RVPP(                                                              \
+            PYBIND11_TYPE(ret_type), PYBIND11_TYPE(cname), name, rvpp, __VA_ARGS__);              \
+        return cname::fn(__VA_ARGS__);                                                            \
+    } while (false)
+
+#define PYBIND11_OVERRIDE_PURE_NAME_RVPP(ret_type, cname, name, fn, rvpp, ...)                    \
+    do {                                                                                          \
+        PYBIND11_OVERRIDE_IMPL_RVPP(                                                              \
+            PYBIND11_TYPE(ret_type), PYBIND11_TYPE(cname), name, rvpp, __VA_ARGS__);              \
+        pybind11::pybind11_fail(                                                                  \
+            "Tried to call pure virtual function \"" PYBIND11_STRINGIFY(cname) "::" name "\"");   \
+    } while (false)
+
 /** \rst
     Macro to populate the virtual method in the trampoline class. This macro tries to look up the
     method from the Python side, deals with the :ref:`gil` and necessary argument conversions to
@@ -3153,21 +3168,6 @@ function get_override(const T *this_ptr, const char *name) {
 #define PYBIND11_OVERRIDE_PURE(ret_type, cname, fn, ...)                                          \
     PYBIND11_OVERRIDE_PURE_NAME(                                                                  \
         PYBIND11_TYPE(ret_type), PYBIND11_TYPE(cname), #fn, fn, __VA_ARGS__)
-
-#define PYBIND11_OVERRIDE_NAME_RVPP(ret_type, cname, name, fn, rvpp, ...)                         \
-    do {                                                                                          \
-        PYBIND11_OVERRIDE_IMPL_RVPP(                                                              \
-            PYBIND11_TYPE(ret_type), PYBIND11_TYPE(cname), name, rvpp, __VA_ARGS__);              \
-        return cname::fn(__VA_ARGS__);                                                            \
-    } while (false)
-
-#define PYBIND11_OVERRIDE_PURE_NAME_RVPP(ret_type, cname, name, fn, rvpp, ...)                    \
-    do {                                                                                          \
-        PYBIND11_OVERRIDE_IMPL_RVPP(                                                              \
-            PYBIND11_TYPE(ret_type), PYBIND11_TYPE(cname), name, rvpp, __VA_ARGS__);              \
-        pybind11::pybind11_fail(                                                                  \
-            "Tried to call pure virtual function \"" PYBIND11_STRINGIFY(cname) "::" name "\"");   \
-    } while (false)
 
 // Deprecated versions
 

--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -102,7 +102,7 @@ public:
         return s.release();
     }
 
-    PYBIND11_TYPE_CASTER(type, const_name("Set[") + key_conv::name + const_name("]"));
+    PYBIND11_TYPE_CASTER_RVPP(type, const_name("Set[") + key_conv::name + const_name("]"));
 };
 
 template <typename Type, typename Key, typename Value>
@@ -158,9 +158,9 @@ public:
         return d.release();
     }
 
-    PYBIND11_TYPE_CASTER(Type,
-                         const_name("Dict[") + key_conv::name + const_name(", ") + value_conv::name
-                             + const_name("]"));
+    PYBIND11_TYPE_CASTER_RVPP(Type,
+                              const_name("Dict[") + key_conv::name + const_name(", ")
+                                  + value_conv::name + const_name("]"));
 };
 
 template <typename Type, typename Value>

--- a/tests/test_class_sh_property_stl.cpp
+++ b/tests/test_class_sh_property_stl.cpp
@@ -8,10 +8,12 @@
 namespace test_class_sh_property_stl {
 
 struct Field {
+    Field(int wrapped_int) : wrapped_int{wrapped_int} {}
     int wrapped_int = 100;
 };
 
 struct FieldHolder {
+    FieldHolder(const Field &fld) : fld{fld} {}
     Field fld = Field{200};
 };
 

--- a/tests/test_return_value_policy_pack.cpp
+++ b/tests/test_return_value_policy_pack.cpp
@@ -106,10 +106,6 @@ int call_level_4_callback_is(const level_4_callback_is &cb) {
 
 } // namespace
 
-#if defined(__CUDACC__) || defined(__MINGW32__)
-PYBIND11_WARNING_DISABLE_GCC("-Wfree-nonheap-object")
-#endif
-
 TEST_SUBMODULE(return_value_policy_pack, m) {
     auto rvpc = py::return_value_policy::_clif_automatic;
     auto rvpb = py::return_value_policy::_return_as_bytes;
@@ -125,8 +121,8 @@ TEST_SUBMODULE(return_value_policy_pack, m) {
         "return_tuple_bytes_str",
         []() {
             // Ensure cast(T*, ...) overload supports rvpp:
-            static auto p = return_pair_string();
-            return &p;
+            static auto *p = new PairString(return_pair_string());
+            return p;
         },
         py::return_value_policy_pack({rvpb, rvpc}));
 
@@ -166,8 +162,8 @@ TEST_SUBMODULE(return_value_policy_pack, m) {
         "return_dict_bytes_str",
         []() {
             // Ensure cast(T*, ...) overload supports rvpp:
-            static auto d = return_map_string();
-            return &d;
+            static auto *d = new MapString(return_map_string());
+            return d;
         },
         py::return_value_policy_pack({rvpb, rvpc}));
 
@@ -188,8 +184,8 @@ TEST_SUBMODULE(return_value_policy_pack, m) {
         "return_set_bs",
         []() {
             // Ensure cast(T*, ...) overload supports rvpp:
-            static auto s = return_set_pair_string();
-            return &s;
+            static auto *s = new SetPairString(return_set_pair_string());
+            return s;
         },
         py::return_value_policy_pack({rvpb, rvpc}));
 
@@ -201,8 +197,8 @@ TEST_SUBMODULE(return_value_policy_pack, m) {
         "return_vector_bs",
         []() {
             // Ensure cast(T*, ...) overload supports rvpp:
-            static auto v = return_vector_pair_string();
-            return &v;
+            static auto *v = new VectorPairString(return_vector_pair_string());
+            return v;
         },
         py::return_value_policy_pack({rvpb, rvpc}));
 
@@ -214,8 +210,8 @@ TEST_SUBMODULE(return_value_policy_pack, m) {
         "return_array_bs",
         []() {
             // Ensure cast(T*, ...) overload supports rvpp:
-            static auto a = return_array_pair_string();
-            return &a;
+            static auto *a = new ArrayPairString(return_array_pair_string());
+            return a;
         },
         py::return_value_policy_pack({rvpb, rvpc}));
 
@@ -232,8 +228,8 @@ TEST_SUBMODULE(return_value_policy_pack, m) {
         "return_optional_bs",
         []() {
             // Ensure cast(T*, ...) overload supports rvpp:
-            static auto o = return_optional_pair_string();
-            return &o;
+            static auto *o = new OptionalPairString(return_optional_pair_string());
+            return o;
         },
         py::return_value_policy_pack({rvpb, rvpc}));
 #endif
@@ -251,8 +247,8 @@ TEST_SUBMODULE(return_value_policy_pack, m) {
         "return_variant_bs",
         []() {
             // Ensure cast(T*, ...) overload supports rvpp:
-            static auto v = return_variant_pair_string();
-            return &v;
+            static auto *v = new VariantPairString(return_variant_pair_string());
+            return v;
         },
         py::return_value_policy_pack({rvpb, rvpc}));
 #endif

--- a/tests/test_return_value_policy_pack.cpp
+++ b/tests/test_return_value_policy_pack.cpp
@@ -129,17 +129,17 @@ struct VirtualBaseTrampoline : VirtualBase {
     static constexpr auto rvpc = py::return_value_policy::_clif_automatic;
     static constexpr auto rvpb = py::return_value_policy::_return_as_bytes;
 
-    virtual int pure() const override {
+    int pure() const override {
         PYBIND11_OVERRIDE_PURE_NAME_RVPP(int, VirtualBase, "py_pure", pure, rvpc,
                                          /* no arguments */);
     }
-    virtual int pure_s(const std::string &a0) const override {
+    int pure_s(const std::string &a0) const override {
         PYBIND11_OVERRIDE_PURE_NAME_RVPP(int, VirtualBase, "py_pure_s", pure_s, rvpc, a0);
     }
-    virtual int pure_b(const std::string &a0) const override {
+    int pure_b(const std::string &a0) const override {
         PYBIND11_OVERRIDE_PURE_NAME_RVPP(int, VirtualBase, "py_pure_b", pure_b, rvpb, a0);
     }
-    virtual int pure_sb(const std::string &a0, const std::string &a1) const override {
+    int pure_sb(const std::string &a0, const std::string &a1) const override {
         PYBIND11_OVERRIDE_PURE_NAME_RVPP(int,
                                          VirtualBase,
                                          "py_pure_sb",
@@ -148,7 +148,7 @@ struct VirtualBaseTrampoline : VirtualBase {
                                          a0,
                                          a1);
     }
-    virtual int pure_bs(const std::string &a0, const std::string &a1) const override {
+    int pure_bs(const std::string &a0, const std::string &a1) const override {
         PYBIND11_OVERRIDE_PURE_NAME_RVPP(int,
                                          VirtualBase,
                                          "py_pure_bs",
@@ -158,17 +158,17 @@ struct VirtualBaseTrampoline : VirtualBase {
                                          a1);
     }
 
-    virtual int nonp() const override {
+    int nonp() const override {
         PYBIND11_OVERRIDE_NAME_RVPP(int, VirtualBase, "py_nonp", nonp, rvpc,
                                     /* no arguments */);
     }
-    virtual int nonp_s(const std::string &a0) const override {
+    int nonp_s(const std::string &a0) const override {
         PYBIND11_OVERRIDE_NAME_RVPP(int, VirtualBase, "py_nonp_s", nonp_s, rvpc, a0);
     }
-    virtual int nonp_b(const std::string &a0) const override {
+    int nonp_b(const std::string &a0) const override {
         PYBIND11_OVERRIDE_NAME_RVPP(int, VirtualBase, "py_nonp_b", nonp_b, rvpb, a0);
     }
-    virtual int nonp_sb(const std::string &a0, const std::string &a1) const override {
+    int nonp_sb(const std::string &a0, const std::string &a1) const override {
         PYBIND11_OVERRIDE_NAME_RVPP(int,
                                     VirtualBase,
                                     "py_nonp_sb",
@@ -177,7 +177,7 @@ struct VirtualBaseTrampoline : VirtualBase {
                                     a0,
                                     a1);
     }
-    virtual int nonp_bs(const std::string &a0, const std::string &a1) const override {
+    int nonp_bs(const std::string &a0, const std::string &a1) const override {
         PYBIND11_OVERRIDE_NAME_RVPP(int,
                                     VirtualBase,
                                     "py_nonp_bs",

--- a/tests/test_return_value_policy_pack.cpp
+++ b/tests/test_return_value_policy_pack.cpp
@@ -119,7 +119,11 @@ TEST_SUBMODULE(return_value_policy_pack, m) {
         py::return_value_policy_pack({rvpc, rvpb}));
     m.def(
         "return_tuple_bytes_str",
-        []() { return return_pair_string(); },
+        []() {
+            // Ensure cast(T*, ...) overload supports rvpp:
+            static auto p = return_pair_string();
+            return &p;
+        },
         py::return_value_policy_pack({rvpb, rvpc}));
 
     m.def("cast_tuple_str_str", [=]() {
@@ -156,7 +160,11 @@ TEST_SUBMODULE(return_value_policy_pack, m) {
         py::return_value_policy_pack({rvpc, rvpb}));
     m.def(
         "return_dict_bytes_str",
-        []() { return return_map_string(); },
+        []() {
+            // Ensure cast(T*, ...) overload supports rvpp:
+            static auto d = return_map_string();
+            return &d;
+        },
         py::return_value_policy_pack({rvpb, rvpc}));
 
     m.def(
@@ -174,7 +182,11 @@ TEST_SUBMODULE(return_value_policy_pack, m) {
         py::return_value_policy_pack({rvpc, rvpb}));
     m.def(
         "return_set_bs",
-        []() { return return_set_pair_string(); },
+        []() {
+            // Ensure cast(T*, ...) overload supports rvpp:
+            static auto s = return_set_pair_string();
+            return &s;
+        },
         py::return_value_policy_pack({rvpb, rvpc}));
 
     m.def(
@@ -183,7 +195,11 @@ TEST_SUBMODULE(return_value_policy_pack, m) {
         py::return_value_policy_pack({rvpc, rvpb}));
     m.def(
         "return_vector_bs",
-        []() { return return_vector_pair_string(); },
+        []() {
+            // Ensure cast(T*, ...) overload supports rvpp:
+            static auto v = return_vector_pair_string();
+            return &v;
+        },
         py::return_value_policy_pack({rvpb, rvpc}));
 
     m.def(
@@ -192,7 +208,11 @@ TEST_SUBMODULE(return_value_policy_pack, m) {
         py::return_value_policy_pack({rvpc, rvpb}));
     m.def(
         "return_array_bs",
-        []() { return return_array_pair_string(); },
+        []() {
+            // Ensure cast(T*, ...) overload supports rvpp:
+            static auto a = return_array_pair_string();
+            return &a;
+        },
         py::return_value_policy_pack({rvpb, rvpc}));
 
     m.attr("PYBIND11_HAS_OPTIONAL") =
@@ -206,7 +226,11 @@ TEST_SUBMODULE(return_value_policy_pack, m) {
         py::return_value_policy_pack({rvpc, rvpb}));
     m.def(
         "return_optional_bs",
-        []() { return return_optional_pair_string(); },
+        []() {
+            // Ensure cast(T*, ...) overload supports rvpp:
+            static auto o = return_optional_pair_string();
+            return &o;
+        },
         py::return_value_policy_pack({rvpb, rvpc}));
 #endif
 
@@ -221,7 +245,11 @@ TEST_SUBMODULE(return_value_policy_pack, m) {
         py::return_value_policy_pack({rvpc, rvpb}));
     m.def(
         "return_variant_bs",
-        []() { return return_variant_pair_string(); },
+        []() {
+            // Ensure cast(T*, ...) overload supports rvpp:
+            static auto v = return_variant_pair_string();
+            return &v;
+        },
         py::return_value_policy_pack({rvpb, rvpc}));
 #endif
 

--- a/tests/test_return_value_policy_pack.cpp
+++ b/tests/test_return_value_policy_pack.cpp
@@ -106,6 +106,10 @@ int call_level_4_callback_is(const level_4_callback_is &cb) {
 
 } // namespace
 
+#if defined(__CUDACC__) || defined(__MINGW32__)
+PYBIND11_WARNING_DISABLE_GCC("-Wfree-nonheap-object")
+#endif
+
 TEST_SUBMODULE(return_value_policy_pack, m) {
     auto rvpc = py::return_value_policy::_clif_automatic;
     auto rvpb = py::return_value_policy::_return_as_bytes;

--- a/tests/test_return_value_policy_pack.cpp
+++ b/tests/test_return_value_policy_pack.cpp
@@ -107,8 +107,8 @@ int call_level_4_callback_is(const level_4_callback_is &cb) {
 } // namespace
 
 TEST_SUBMODULE(return_value_policy_pack, m) {
-    auto rvpc = py::return_value_policy::_clif_automatic;
-    auto rvpb = py::return_value_policy::_return_as_bytes;
+    static constexpr auto rvpc = py::return_value_policy::_clif_automatic;
+    static constexpr auto rvpb = py::return_value_policy::_return_as_bytes;
 
     m.def("return_tuple_str_str", []() { return return_pair_string(); });
     m.def(
@@ -126,16 +126,16 @@ TEST_SUBMODULE(return_value_policy_pack, m) {
         },
         py::return_value_policy_pack({rvpb, rvpc}));
 
-    m.def("cast_tuple_str_str", [=]() {
+    m.def("cast_tuple_str_str", []() {
         return py::cast(return_pair_string(), py::return_value_policy_pack({rvpc, rvpc}));
     });
-    m.def("cast_tuple_bytes_bytes", [=]() {
+    m.def("cast_tuple_bytes_bytes", []() {
         return py::cast(return_pair_string(), py::return_value_policy_pack({rvpb, rvpb}));
     });
-    m.def("cast_tuple_str_bytes", [=]() {
+    m.def("cast_tuple_str_bytes", []() {
         return py::cast(return_pair_string(), py::return_value_policy_pack({rvpc, rvpb}));
     });
-    m.def("cast_tuple_bytes_str", [=]() {
+    m.def("cast_tuple_bytes_str", []() {
         return py::cast(return_pair_string(), py::return_value_policy_pack({rvpb, rvpc}));
     });
 

--- a/tests/test_return_value_policy_pack.cpp
+++ b/tests/test_return_value_policy_pack.cpp
@@ -130,8 +130,7 @@ struct VirtualBaseTrampoline : VirtualBase {
     static constexpr auto rvpb = py::return_value_policy::_return_as_bytes;
 
     int pure() const override {
-        PYBIND11_OVERRIDE_PURE_NAME_RVPP(int, VirtualBase, "py_pure", pure, rvpc,
-                                         /* no arguments */);
+        PYBIND11_OVERRIDE_PURE_NAME_RVPP(int, VirtualBase, "py_pure", pure, rvpc);
     }
     int pure_s(const std::string &a0) const override {
         PYBIND11_OVERRIDE_PURE_NAME_RVPP(int, VirtualBase, "py_pure_s", pure_s, rvpc, a0);
@@ -159,8 +158,7 @@ struct VirtualBaseTrampoline : VirtualBase {
     }
 
     int nonp() const override {
-        PYBIND11_OVERRIDE_NAME_RVPP(int, VirtualBase, "py_nonp", nonp, rvpc,
-                                    /* no arguments */);
+        PYBIND11_OVERRIDE_NAME_RVPP(int, VirtualBase, "py_nonp", nonp, rvpc);
     }
     int nonp_s(const std::string &a0) const override {
         PYBIND11_OVERRIDE_NAME_RVPP(int, VirtualBase, "py_nonp_s", nonp_s, rvpc, a0);

--- a/tests/test_return_value_policy_pack.cpp
+++ b/tests/test_return_value_policy_pack.cpp
@@ -122,6 +122,19 @@ TEST_SUBMODULE(return_value_policy_pack, m) {
         []() { return return_pair_string(); },
         py::return_value_policy_pack({rvpb, rvpc}));
 
+    m.def("cast_tuple_str_str", [=]() {
+        return py::cast(return_pair_string(), py::return_value_policy_pack({rvpc, rvpc}));
+    });
+    m.def("cast_tuple_bytes_bytes", [=]() {
+        return py::cast(return_pair_string(), py::return_value_policy_pack({rvpb, rvpb}));
+    });
+    m.def("cast_tuple_str_bytes", [=]() {
+        return py::cast(return_pair_string(), py::return_value_policy_pack({rvpc, rvpb}));
+    });
+    m.def("cast_tuple_bytes_str", [=]() {
+        return py::cast(return_pair_string(), py::return_value_policy_pack({rvpb, rvpc}));
+    });
+
     m.def("return_nested_tuple_str", []() { return return_nested_pair_string(); });
     m.def(
         "return_nested_tuple_bytes", []() { return return_nested_pair_string(); }, rvpb);

--- a/tests/test_return_value_policy_pack.cpp
+++ b/tests/test_return_value_policy_pack.cpp
@@ -108,6 +108,9 @@ struct VirtualBase {
     VirtualBase() = default;
     virtual ~VirtualBase() = default;
 
+    // Some compilers complain about implicitly defined versions of some of the following:
+    VirtualBase(const VirtualBase &) = default;
+
     virtual int pure() const = 0;
     virtual int pure_s(const std::string & /*a0*/) const = 0;
     virtual int pure_b(const std::string & /*a0*/) const = 0;

--- a/tests/test_return_value_policy_pack.py
+++ b/tests/test_return_value_policy_pack.py
@@ -10,6 +10,10 @@ from pybind11_tests import return_value_policy_pack as m
         (m.return_tuple_bytes_bytes, (bytes, bytes)),
         (m.return_tuple_str_bytes, (str, bytes)),
         (m.return_tuple_bytes_str, (bytes, str)),
+        (m.cast_tuple_str_str, (str, str)),
+        (m.cast_tuple_bytes_bytes, (bytes, bytes)),
+        (m.cast_tuple_str_bytes, (str, bytes)),
+        (m.cast_tuple_bytes_str, (bytes, str)),
     ],
 )
 def test_return_pair_string(func, expected):

--- a/tests/test_return_value_policy_pack.py
+++ b/tests/test_return_value_policy_pack.py
@@ -251,3 +251,80 @@ def test_nested_callbacks_is_b():
     assert m.call_level_2_callback_is_b(cb_2) == 20120
     assert m.call_level_3_callback_is_b(cb_3) == 40101
     assert m.call_level_4_callback_is_b(cb_4) == 60120
+
+
+CALL_VIRTUAL_OVERRIDES_WHICH_EXPECTED = [
+    ("pure", 9),
+    ("pure_s", 10),
+    ("pure_b", 11),
+    ("pure_sb", 101),
+    ("pure_bs", 110),
+    ("nonp", 8),
+    ("nonp_s", 20),
+    ("nonp_b", 21),
+    ("nonp_sb", 201),
+    ("nonp_bs", 210),
+]
+
+
+@pytest.mark.parametrize(("which", "expected"), CALL_VIRTUAL_OVERRIDES_WHICH_EXPECTED)
+def test_virtual_overrides_drvd(which, expected):
+    class Drvd(m.VirtualBase):
+        def py_pure(self):
+            return 9
+
+        def py_pure_s(self, a0):
+            assert isinstance(a0, str)
+            return 10
+
+        def py_pure_b(self, a0):
+            assert isinstance(a0, bytes)
+            return 11
+
+        def py_pure_sb(self, a0, a1):
+            assert isinstance(a0, str)
+            assert isinstance(a1, bytes)
+            return 101
+
+        def py_pure_bs(self, a0, a1):
+            assert isinstance(a0, bytes)
+            assert isinstance(a1, str)
+            return 110
+
+        def py_nonp(self):
+            return 8
+
+        def py_nonp_s(self, a0):
+            assert isinstance(a0, str)
+            return 20
+
+        def py_nonp_b(self, a0):
+            assert isinstance(a0, bytes)
+            return 21
+
+        def py_nonp_sb(self, a0, a1):
+            assert isinstance(a0, str)
+            assert isinstance(a1, bytes)
+            return 201
+
+        def py_nonp_bs(self, a0, a1):
+            assert isinstance(a0, bytes)
+            assert isinstance(a1, str)
+            return 210
+
+    d = Drvd()
+    assert m.call_virtual_override(d, which) == expected
+
+
+@pytest.mark.parametrize(("which", "expected"), CALL_VIRTUAL_OVERRIDES_WHICH_EXPECTED)
+def test_virtual_overrides_base(which, expected):
+    b = m.VirtualBase()
+    if which.startswith("pure"):
+        with pytest.raises(RuntimeError) as exc_info:
+            m.call_virtual_override(b, which)
+        assert (
+            str(exc_info.value)
+            == f'Tried to call pure virtual function "VirtualBase::py_{which}"'
+        )
+    else:
+        assert m.call_virtual_override(b, which) == -expected


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
Follow-on to #30011, to make the `return_value_policy_pack` support more complete:

* `py::cast()`
* macros for trampolines: `PYBIND11_OVERRIDE_NAME_RVPP`, `PYBIND11_OVERRIDE_PURE_NAME_RVPP`

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
