### PR TITLE
Add `type_caster<PyObject>`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,7 +151,8 @@ set(PYBIND11_HEADERS
     include/pybind11/stl.h
     include/pybind11/stl_bind.h
     include/pybind11/stl/filesystem.h
-    include/pybind11/trampoline_self_life_support.h)
+    include/pybind11/trampoline_self_life_support.h
+    include/pybind11/type_caster_pyobject_ptr.h)
 
 # Compare with grep and warn if mismatched
 if(PYBIND11_MASTER_PROJECT AND NOT CMAKE_VERSION VERSION_LESS 3.12)

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1238,7 +1238,7 @@ T cast(const handle &handle) {
 template <typename T,
           detail::enable_if_t<detail::is_same_ignoring_cvref<T, PyObject *>::value, int> = 0>
 T cast(const handle &handle) {
-    return handle.ptr();
+    return handle.inc_ref().ptr();
 }
 
 // C++ type -> py::object

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1235,6 +1235,10 @@ T cast(const handle &handle) {
     return T(reinterpret_borrow<object>(handle));
 }
 
+// Note that `cast<PyObject *>(obj)` increments the reference count of `obj`.
+// This is necessary for the case that `obj` is a temporary.
+// It is the responsibility of the caller to ensure that the reference count
+// is decremented.
 template <typename T,
           detail::enable_if_t<detail::is_same_ignoring_cvref<T, PyObject *>::value, int> = 0>
 T cast(const handle &handle) {

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1207,7 +1207,11 @@ make_caster<T> load_type(const handle &handle) {
 PYBIND11_NAMESPACE_END(detail)
 
 // pytype -> C++ type
-template <typename T, detail::enable_if_t<!detail::is_pyobject<T>::value, int> = 0>
+template <typename T,
+          detail::enable_if_t<!detail::is_pyobject<T>::value
+                                  && !detail::is_same_ignoring_cvref<T, PyObject *>::value,
+                              int>
+          = 0>
 T cast(const handle &handle) {
     using namespace detail;
     constexpr bool is_enum_cast = type_uses_type_caster_enum_type<intrinsic_t<T>>::value;
@@ -1229,6 +1233,12 @@ T cast(const handle &handle) {
 template <typename T, detail::enable_if_t<detail::is_pyobject<T>::value, int> = 0>
 T cast(const handle &handle) {
     return T(reinterpret_borrow<object>(handle));
+}
+
+template <typename T,
+          detail::enable_if_t<detail::is_same_ignoring_cvref<T, PyObject *>::value, int> = 0>
+T cast(const handle &handle) {
+    return handle.ptr();
 }
 
 // C++ type -> py::object

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -751,6 +751,10 @@ template <class T>
 using remove_cvref_t = typename remove_cvref<T>::type;
 #endif
 
+/// Example usage: is_same_ignoring_cvref<T, PyObject *>
+template <typename T, typename U>
+using is_same_ignoring_cvref = std::is_same<detail::remove_cvref_t<T>, U>;
+
 /// Index sequences
 #if defined(PYBIND11_CPP14)
 using std::index_sequence;

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -751,7 +751,7 @@ template <class T>
 using remove_cvref_t = typename remove_cvref<T>::type;
 #endif
 
-/// Example usage: is_same_ignoring_cvref<T, PyObject *>
+/// Example usage: is_same_ignoring_cvref<T, PyObject *>::value
 template <typename T, typename U>
 using is_same_ignoring_cvref = std::is_same<detail::remove_cvref_t<T>, U>;
 

--- a/include/pybind11/type_caster_pyobject_ptr.h
+++ b/include/pybind11/type_caster_pyobject_ptr.h
@@ -1,0 +1,57 @@
+// Copyright (c) 2023 The pybind Community.
+
+#pragma once
+
+#include "detail/common.h"
+#include "detail/descr.h"
+#include "cast.h"
+#include "pytypes.h"
+
+PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
+PYBIND11_NAMESPACE_BEGIN(detail)
+
+template <>
+class type_caster<PyObject> {
+public:
+    static constexpr auto name = const_name("PyObject *");
+
+    // This overload is purely to guard against accidents.
+    template <typename T,
+              detail::enable_if_t<!is_same_ignoring_cvref<T, PyObject *>::value, int> = 0>
+    static handle cast(T &&, return_value_policy, handle /*parent*/) {
+        static_assert(is_same_ignoring_cvref<T, PyObject *>::value,
+                      "Invalid C++ type T for to-Python conversion (type_caster<PyObject>).");
+        return nullptr; // Unreachable.
+    }
+
+    static handle cast(PyObject *src, return_value_policy policy, handle /*parent*/) {
+        if (src == nullptr) {
+            throw error_already_set();
+        }
+        if (PyErr_Occurred()) {
+            raise_from(PyExc_SystemError, "src != nullptr but PyErr_Occurred()");
+            throw error_already_set();
+        }
+        if (policy == return_value_policy::take_ownership) {
+            return src;
+        }
+        Py_INCREF(src);
+        return src;
+    }
+
+    bool load(handle src, bool) {
+        value = reinterpret_borrow<object>(src);
+        return true;
+    }
+
+    template <typename T>
+    using cast_op_type = PyObject *;
+
+    explicit operator PyObject *() { return value.ptr(); }
+
+private:
+    object value;
+};
+
+PYBIND11_NAMESPACE_END(detail)
+PYBIND11_NAMESPACE_END(PYBIND11_NAMESPACE)

--- a/include/pybind11/type_caster_pyobject_ptr.h
+++ b/include/pybind11/type_caster_pyobject_ptr.h
@@ -36,8 +36,12 @@ public:
             || policy == return_value_policy::_clif_automatic) {
             return src;
         }
-        Py_INCREF(src);
-        return src;
+        if (policy == return_value_policy::reference
+            || policy == return_value_policy::automatic_reference) {
+            return handle(src).inc_ref();
+        }
+        pybind11_fail("type_caster<PyObject>::cast(): unsupported return_value_policy: "
+                      + std::to_string(static_cast<int>(policy)));
     }
 
     bool load(handle src, bool) {

--- a/include/pybind11/type_caster_pyobject_ptr.h
+++ b/include/pybind11/type_caster_pyobject_ptr.h
@@ -32,7 +32,8 @@ public:
             raise_from(PyExc_SystemError, "src != nullptr but PyErr_Occurred()");
             throw error_already_set();
         }
-        if (policy == return_value_policy::take_ownership) {
+        if (policy == return_value_policy::take_ownership
+            || policy == return_value_policy::_clif_automatic) {
             return src;
         }
         Py_INCREF(src);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -180,6 +180,7 @@ set(PYBIND11_TEST_FILES
     test_thread
     test_type_caster_odr_guard_1
     test_type_caster_odr_guard_2
+    test_type_caster_pyobject_ptr
     test_union
     test_virtual_functions)
 

--- a/tests/extra_python_package/test_files.py
+++ b/tests/extra_python_package/test_files.py
@@ -46,6 +46,7 @@ main_headers = {
     "include/pybind11/stl.h",
     "include/pybind11/stl_bind.h",
     "include/pybind11/trampoline_self_life_support.h",
+    "include/pybind11/type_caster_pyobject_ptr.h",
 }
 
 detail_headers = {

--- a/tests/test_type_caster_pyobject_ptr.cpp
+++ b/tests/test_type_caster_pyobject_ptr.cpp
@@ -90,8 +90,8 @@ TEST_SUBMODULE(type_caster_pyobject_ptr, m) {
         std::size_t i = 0;
         for (; i < vec_obj.size(); i++) {
             py::handle h(vec_obj[i]);
-            if (static_cast<std::size_t>(h.ref_count()) < i) {
-                break;
+            if (static_cast<std::size_t>(h.ref_count()) < 2) {
+                break; // Something is badly wrong.
             }
             h.dec_ref();
         }

--- a/tests/test_type_caster_pyobject_ptr.cpp
+++ b/tests/test_type_caster_pyobject_ptr.cpp
@@ -21,12 +21,9 @@ TEST_SUBMODULE(type_caster_pyobject_ptr, m) {
     m.def("pass_pyobject_ptr", [](PyObject *obj) { return bool(PyTuple_CheckExact(obj)); });
 
     m.def("call_callback_with_object_return",
-          [](const std::function<py::object(int mode)> &cb, int mode) { return cb(mode); });
-    m.def("call_callback_with_handle_return",
-          [](const std::function<py::handle(int mode)> &cb, int mode) { return cb(mode); });
-    //
+          [](const std::function<py::object(int)> &cb, int value) { return cb(value); });
     m.def("call_callback_with_pyobject_ptr_return",
-          [](const std::function<PyObject *(int mode)> &cb, int mode) { return cb(mode); });
+          [](const std::function<PyObject *(int)> &cb, int value) { return cb(value); });
     m.def("call_callback_with_pyobject_ptr_arg",
           [](const std::function<bool(PyObject *)> &cb, py::handle obj) { return cb(obj.ptr()); });
 

--- a/tests/test_type_caster_pyobject_ptr.cpp
+++ b/tests/test_type_caster_pyobject_ptr.cpp
@@ -1,0 +1,52 @@
+#include <pybind11/functional.h>
+#include <pybind11/type_caster_pyobject_ptr.h>
+
+#include "pybind11_tests.h"
+
+TEST_SUBMODULE(type_caster_pyobject_ptr, m) {
+    m.def("cast_from_pyobject_ptr", []() {
+        PyObject *ptr = PyLong_FromLongLong(6758L);
+        py::object retval = py::cast(ptr, py::return_value_policy::take_ownership);
+        return retval;
+    });
+    m.def("cast_to_pyobject_ptr", [](py::handle obj) {
+        auto *ptr = py::cast<PyObject *>(obj);
+        return bool(PyTuple_CheckExact(ptr));
+    });
+
+    m.def(
+        "return_pyobject_ptr",
+        []() { return PyLong_FromLongLong(2314L); },
+        py::return_value_policy::take_ownership);
+    m.def("pass_pyobject_ptr", [](PyObject *obj) { return bool(PyTuple_CheckExact(obj)); });
+
+    m.def("call_callback_with_object_return",
+          [](const std::function<py::object(int mode)> &cb, int mode) { return cb(mode); });
+    m.def("call_callback_with_handle_return",
+          [](const std::function<py::handle(int mode)> &cb, int mode) { return cb(mode); });
+    //
+    m.def("call_callback_with_pyobject_ptr_return",
+          [](const std::function<PyObject *(int mode)> &cb, int mode) { return cb(mode); });
+    m.def("call_callback_with_pyobject_ptr_arg",
+          [](const std::function<bool(PyObject *)> &cb, py::handle obj) { return cb(obj.ptr()); });
+
+    m.def("cast_to_pyobject_ptr_nullptr", [](bool set_error) {
+        if (set_error) {
+            PyErr_SetString(PyExc_RuntimeError, "Reflective of healthy error handling.");
+        }
+        PyObject *ptr = nullptr;
+        py::cast(ptr);
+    });
+
+    m.def("cast_to_pyobject_ptr_non_nullptr_with_error_set", []() {
+        PyErr_SetString(PyExc_RuntimeError, "Reflective of unhealthy error handling.");
+        py::cast(Py_None);
+    });
+
+#ifdef PYBIND11_NO_COMPILE_SECTION // Change to ifndef for manual testing.
+    {
+        PyObject *ptr = nullptr;
+        (void) py::cast(*ptr);
+    }
+#endif
+}

--- a/tests/test_type_caster_pyobject_ptr.cpp
+++ b/tests/test_type_caster_pyobject_ptr.cpp
@@ -22,10 +22,15 @@ TEST_SUBMODULE(type_caster_pyobject_ptr, m) {
 
     m.def("call_callback_with_object_return",
           [](const std::function<py::object(int)> &cb, int value) { return cb(value); });
-    m.def("call_callback_with_pyobject_ptr_return",
-          [](const std::function<PyObject *(int)> &cb, int value) { return cb(value); });
-    m.def("call_callback_with_pyobject_ptr_arg",
-          [](const std::function<bool(PyObject *)> &cb, py::handle obj) { return cb(obj.ptr()); });
+    m.def(
+        "call_callback_with_pyobject_ptr_return",
+        [](const std::function<PyObject *(int)> &cb, int value) { return cb(value); },
+        py::return_value_policy::take_ownership);
+    m.def(
+        "call_callback_with_pyobject_ptr_arg",
+        [](const std::function<bool(PyObject *)> &cb, py::handle obj) { return cb(obj.ptr()); },
+        py::arg("cb"), // This triggers return_value_policy::automatic_reference
+        py::arg("obj"));
 
     m.def("cast_to_pyobject_ptr_nullptr", [](bool set_error) {
         if (set_error) {

--- a/tests/test_type_caster_pyobject_ptr.py
+++ b/tests/test_type_caster_pyobject_ptr.py
@@ -69,3 +69,23 @@ def test_cast_to_python_non_nullptr_with_error_set():
         m.cast_to_pyobject_ptr_non_nullptr_with_error_set()
     assert str(excinfo.value) == "src != nullptr but PyErr_Occurred()"
     assert str(excinfo.value.__cause__) == "Reflective of unhealthy error handling."
+
+
+def test_pass_list_pyobject_ptr():
+    acc = m.pass_list_pyobject_ptr([ValueHolder(842), ValueHolder(452)])
+    assert acc == 842452
+
+
+def test_return_list_pyobject_ptr_take_ownership():
+    vec_obj = m.return_list_pyobject_ptr_take_ownership(ValueHolder)
+    assert [e.value for e in vec_obj] == [93, 186]
+
+
+def test_return_list_pyobject_ptr_reference():
+    vec_obj = m.return_list_pyobject_ptr_reference(ValueHolder)
+    assert [e.value for e in vec_obj] == [93, 186]
+    # Commenting out the next `assert` will leak the Python references.
+    # An easy way to see evidence of the leaks:
+    # Insert `while True:` as the first line of this function and monitor the
+    # process RES (Resident Memory Size) with the Unix top command.
+    assert m.dec_ref_each_pyobject_ptr(vec_obj) == 2

--- a/tests/test_type_caster_pyobject_ptr.py
+++ b/tests/test_type_caster_pyobject_ptr.py
@@ -3,13 +3,18 @@ import pytest
 from pybind11_tests import type_caster_pyobject_ptr as m
 
 
+# For use as a temporary user-defined object, to maximize sensitivity of the tests below.
+class ValueHolder:
+    def __init__(self, value):
+        self.value = value
+
+
 def test_cast_from_pyobject_ptr():
     assert m.cast_from_pyobject_ptr() == 6758
 
 
 def test_cast_to_pyobject_ptr():
-    assert m.cast_to_pyobject_ptr(())
-    assert not m.cast_to_pyobject_ptr({})
+    assert m.cast_to_pyobject_ptr(ValueHolder(24)) == 76
 
 
 def test_return_pyobject_ptr():
@@ -17,13 +22,7 @@ def test_return_pyobject_ptr():
 
 
 def test_pass_pyobject_ptr():
-    assert m.pass_pyobject_ptr(())
-    assert not m.pass_pyobject_ptr({})
-
-
-class ValueHolder:
-    def __init__(self, value):
-        self.value = value
+    assert m.pass_pyobject_ptr(ValueHolder(82)) == 118
 
 
 @pytest.mark.parametrize(
@@ -37,7 +36,6 @@ def test_call_callback_with_object_return(call_callback):
     def cb(value):
         if value < 0:
             raise ValueError("Raised from cb")
-        # Return a temporary user-defined object, to maximize sensitivity of this test.
         return ValueHolder(1000 - value)
 
     assert call_callback(cb, 287).value == 713
@@ -48,10 +46,9 @@ def test_call_callback_with_object_return(call_callback):
 
 def test_call_callback_with_pyobject_ptr_arg():
     def cb(obj):
-        return isinstance(obj, tuple)
+        return 300 - obj.value
 
-    assert m.call_callback_with_pyobject_ptr_arg(cb, ())
-    assert not m.call_callback_with_pyobject_ptr_arg(cb, {})
+    assert m.call_callback_with_pyobject_ptr_arg(cb, ValueHolder(39)) == 261
 
 
 @pytest.mark.parametrize("set_error", [True, False])

--- a/tests/test_type_caster_pyobject_ptr.py
+++ b/tests/test_type_caster_pyobject_ptr.py
@@ -1,0 +1,71 @@
+import pytest
+
+from pybind11_tests import type_caster_pyobject_ptr as m
+
+
+def test_cast_from_pyobject_ptr():
+    assert m.cast_from_pyobject_ptr() == 6758
+
+
+def test_cast_to_pyobject_ptr():
+    assert m.cast_to_pyobject_ptr(())
+    assert not m.cast_to_pyobject_ptr({})
+
+
+def test_return_pyobject_ptr():
+    assert m.return_pyobject_ptr() == 2314
+
+
+def test_pass_pyobject_ptr():
+    assert m.pass_pyobject_ptr(())
+    assert not m.pass_pyobject_ptr({})
+
+
+@pytest.mark.parametrize(
+    "call_callback",
+    [
+        m.call_callback_with_object_return,
+        m.call_callback_with_handle_return,
+        m.call_callback_with_pyobject_ptr_return,
+    ],
+)
+def test_call_callback_with_object_return(call_callback):
+    def cb(mode):
+        if mode == 0:
+            return 10
+        if mode == 1:
+            return "One"
+        raise NotImplementedError(f"Unknown mode: {mode}")
+
+    assert call_callback(cb, 0) == 10
+    assert call_callback(cb, 1) == "One"
+    with pytest.raises(NotImplementedError, match="Unknown mode: 2"):
+        call_callback(cb, 2)
+
+
+def test_call_callback_with_pyobject_ptr_arg():
+    def cb(obj):
+        return isinstance(obj, tuple)
+
+    assert m.call_callback_with_pyobject_ptr_arg(cb, ())
+    assert not m.call_callback_with_pyobject_ptr_arg(cb, {})
+
+
+@pytest.mark.parametrize("set_error", [True, False])
+def test_cast_to_python_nullptr(set_error):
+    expected = {
+        True: r"^Reflective of healthy error handling\.$",
+        False: (
+            r"^Internal error: pybind11::error_already_set called "
+            r"while Python error indicator not set\.$"
+        ),
+    }[set_error]
+    with pytest.raises(RuntimeError, match=expected):
+        m.cast_to_pyobject_ptr_nullptr(set_error)
+
+
+def test_cast_to_python_non_nullptr_with_error_set():
+    with pytest.raises(SystemError) as excinfo:
+        m.cast_to_pyobject_ptr_non_nullptr_with_error_set()
+    assert str(excinfo.value) == "src != nullptr but PyErr_Occurred()"
+    assert str(excinfo.value.__cause__) == "Reflective of unhealthy error handling."


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
This is to support automatic wrapping of APIs that make use of `PyObject *`. It is impractical to rewrite all such APIs to use `py::handle` or `py::object` (although that would of course be ideal).

Back-ported under pybind/pybind11#4601

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
