### PR TITLE
Snapshot of WIP: Add `format_descriptor<PyObject *>`

### DIFF
--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -1148,6 +1148,15 @@ struct format_descriptor<T, detail::enable_if_t<std::is_arithmetic<T>::value>> {
     static std::string format() { return std::string(1, c); }
 };
 
+template <typename T>
+struct format_descriptor<
+    T,
+    detail::enable_if_t<detail::is_same_ignoring_cvref<T, PyObject *>::value>> {
+    static constexpr const char c = 'O';
+    static constexpr const char value[2] = {c, '\0'};
+    static std::string format() { return std::string(1, c); }
+};
+
 #if !defined(PYBIND11_CPP17)
 
 template <typename T>


### PR DESCRIPTION
Add `format_descriptor<PyObject *>`

Originally tested under cl/522005071, in combination with changes under pybind11_abseil:

```diff
--- a/pybind11_abseil/absl_casters.h
+++ b/pybind11_abseil/absl_casters.h
@@ -33,6 +33,7 @@
 #include <pybind11/cast.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
+#include <pybind11/type_caster_pyobject_ptr.h>

 #include <cmath>
 #include <cstdint>
@@ -282,8 +283,10 @@ struct type_caster<absl::CivilYear>

 // Returns {true, a span referencing the data contained by src} without copying
 // or converting the data if possible. Otherwise returns {false, an empty span}.
-template <typename T, typename std::enable_if<std::is_arithmetic<T>::value,
-                                              bool>::type = true>
+template <typename T, typename std::enable_if<
+                          std::is_arithmetic<T>::value ||
+                              is_same_ignoring_cvref<T, PyObject*>::value,
+                          bool>::type = true>
 std::tuple<bool, absl::Span<T>> LoadSpanFromBuffer(handle src) {
   Py_buffer view;
   int flags = PyBUF_STRIDES | PyBUF_FORMAT;
@@ -301,8 +304,10 @@ std::tuple<bool, absl::Span<T>> LoadSpan
   return {false, absl::Span<T>()};
 }
 // If T is not a numeric type, the buffer interface cannot be used.
-template <typename T, typename std::enable_if<!std::is_arithmetic<T>::value,
-                                              bool>::type = true>
+template <typename T, typename std::enable_if<
+                          !std::is_arithmetic<T>::value &&
+                              !is_same_ignoring_cvref<T, PyObject*>::value,
+                          bool>::type = true>
 constexpr std::tuple<bool, absl::Span<T>> LoadSpanFromBuffer(handle src) {
   return {false, absl::Span<T>()};
 }
```

<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
