### PR TITLE
`from_python_policies` `automatic_reference` bug fix

### DIFF
--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -606,7 +606,8 @@ struct from_python_policies {
         : rvpp(return_value_policy::automatic_reference), convert(true), none(true) {}
 
     // NOLINTNEXTLINE(google-explicit-constructor)
-    from_python_policies(bool convert, bool none = true) : convert(convert), none(none) {}
+    from_python_policies(bool convert, bool none = true)
+        : rvpp(return_value_policy::automatic_reference), convert(convert), none(none) {}
 
     // NOLINTNEXTLINE(google-explicit-constructor)
     from_python_policies(const return_value_policy_pack &rvpp)

--- a/tests/test_return_value_policy_pack.cpp
+++ b/tests/test_return_value_policy_pack.cpp
@@ -224,6 +224,15 @@ int call_virtual_override(const VirtualBase &base, const std::string &which) {
     return -99; // Invalid which.
 }
 
+struct IntOwner {
+    int val = 3;
+};
+
+int call_callback_pass_int_owner_const_ptr(const std::function<int(const IntOwner *)> &cb) {
+    IntOwner int_owner;
+    return cb(&int_owner) + 500;
+}
+
 } // namespace return_value_policy_pack
 } // namespace pybind11_tests
 
@@ -426,4 +435,8 @@ TEST_SUBMODULE(return_value_policy_pack, m) {
         .def("py_nonp_bs", &VirtualBase::nonp_bs, py::arg("a0"), py::arg("a1"));
 
     m.def("call_virtual_override", call_virtual_override);
+
+    py::class_<IntOwner>(m, "IntOwner").def_readonly("val", &IntOwner::val);
+
+    m.def("call_callback_pass_int_owner_const_ptr", call_callback_pass_int_owner_const_ptr);
 }

--- a/tests/test_return_value_policy_pack.cpp
+++ b/tests/test_return_value_policy_pack.cpp
@@ -18,7 +18,8 @@
 #    include <variant>
 #endif
 
-namespace {
+namespace pybind11_tests {
+namespace return_value_policy_pack {
 
 using PairString = std::pair<std::string, std::string>;
 
@@ -223,7 +224,10 @@ int call_virtual_override(const VirtualBase &base, const std::string &which) {
     return -99; // Invalid which.
 }
 
-} // namespace
+} // namespace return_value_policy_pack
+} // namespace pybind11_tests
+
+using namespace pybind11_tests::return_value_policy_pack;
 
 TEST_SUBMODULE(return_value_policy_pack, m) {
     static constexpr auto rvpc = py::return_value_policy::_clif_automatic;

--- a/tests/test_return_value_policy_pack.py
+++ b/tests/test_return_value_policy_pack.py
@@ -328,3 +328,10 @@ def test_virtual_overrides_base(which, expected):
         )
     else:
         assert m.call_virtual_override(b, which) == -expected
+
+
+def test_call_callback_pass_int_owner():
+    def cb(int_owner):
+        return int_owner.val + 40
+
+    assert m.call_callback_pass_int_owner_const_ptr(cb) == 543


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
The bug fixed in this PR was discovered through Google global testing.

The failing test was:

* https://github.com/mitsuba-renderer/mitsuba3/blob/ede09ae55dd747a008f74f1a5f4889f371029ae4/src/core/tests/test_python.py#L90

The unit test added in this PR reproduces the conditions.

Testing with the fix commented out:

```diff
diff --git a/include/pybind11/detail/common.h b/include/pybind11/detail/common.h
index 98d23600..3bad6855 100644
--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -607,7 +607,7 @@ struct from_python_policies {

     // NOLINTNEXTLINE(google-explicit-constructor)
     from_python_policies(bool convert, bool none = true)
-        : rvpp(return_value_policy::automatic_reference), convert(convert), none(none) {}
+        : /*rvpp(return_value_policy::automatic_reference),*/ convert(convert), none(none) {}

     // NOLINTNEXTLINE(google-explicit-constructor)
     from_python_policies(const return_value_policy_pack &rvpp)
```

```
Running tests in directory "/usr/local/google/home/rwgk/forked/pybind11/tests":
============================= test session starts ==============================
platform linux -- Python 3.10.9, pytest-7.1.2, pluggy-1.0.0 -- /usr/bin/python3
cachedir: .pytest_cache
C++ Info: Debian Clang 14.0.6 C++17 __pybind11_internals_v4_clang_libstdcpp_cxxabi1002_sh_def__ PYBIND11_SIMPLE_GIL_MANAGEMENT=False
rootdir: /usr/local/google/home/rwgk/forked/pybind11/tests, configfile: pytest.ini
plugins: xdist-3.0.2, flakefinder-1.1.0
collecting ... collected 58 items / 57 deselected / 1 selected

test_return_value_policy_pack.py::test_call_callback_pass_int_owner munmap_chunk(): invalid pointer
Fatal Python error: Aborted

Current thread 0x00007f686e834040 (most recent call first):
  File "/usr/local/google/home/rwgk/forked/pybind11/tests/test_return_value_policy_pack.py", line 337 in test_call_callback_pass_int_owner
  File "/usr/local/lib/python3.10/dist-packages/_pytest/python.py", line 192 in pytest_pyfunc_call
  File "/usr/local/lib/python3.10/dist-packages/pluggy/_callers.py", line 39 in _multicall
  File "/usr/local/lib/python3.10/dist-packages/pluggy/_manager.py", line 80 in _hookexec
  File "/usr/local/lib/python3.10/dist-packages/pluggy/_hooks.py", line 265 in __call__
  File "/usr/local/lib/python3.10/dist-packages/_pytest/python.py", line 1761 in runtest
  File "/usr/local/lib/python3.10/dist-packages/_pytest/runner.py", line 166 in pytest_runtest_call
  File "/usr/local/lib/python3.10/dist-packages/pluggy/_callers.py", line 39 in _multicall
  File "/usr/local/lib/python3.10/dist-packages/pluggy/_manager.py", line 80 in _hookexec
  File "/usr/local/lib/python3.10/dist-packages/pluggy/_hooks.py", line 265 in __call__
  File "/usr/local/lib/python3.10/dist-packages/_pytest/runner.py", line 259 in <lambda>
  File "/usr/local/lib/python3.10/dist-packages/_pytest/runner.py", line 338 in from_call
  File "/usr/local/lib/python3.10/dist-packages/_pytest/runner.py", line 258 in call_runtest_hook
  File "/usr/local/lib/python3.10/dist-packages/_pytest/runner.py", line 219 in call_and_report
  File "/usr/local/lib/python3.10/dist-packages/_pytest/runner.py", line 130 in runtestprotocol
  File "/usr/local/lib/python3.10/dist-packages/_pytest/runner.py", line 111 in pytest_runtest_protocol
  File "/usr/local/lib/python3.10/dist-packages/pluggy/_callers.py", line 39 in _multicall
  File "/usr/local/lib/python3.10/dist-packages/pluggy/_manager.py", line 80 in _hookexec
  File "/usr/local/lib/python3.10/dist-packages/pluggy/_hooks.py", line 265 in __call__
  File "/usr/local/lib/python3.10/dist-packages/_pytest/main.py", line 347 in pytest_runtestloop
  File "/usr/local/lib/python3.10/dist-packages/pluggy/_callers.py", line 39 in _multicall
  File "/usr/local/lib/python3.10/dist-packages/pluggy/_manager.py", line 80 in _hookexec
  File "/usr/local/lib/python3.10/dist-packages/pluggy/_hooks.py", line 265 in __call__
  File "/usr/local/lib/python3.10/dist-packages/_pytest/main.py", line 322 in _main
  File "/usr/local/lib/python3.10/dist-packages/_pytest/main.py", line 268 in wrap_session
  File "/usr/local/lib/python3.10/dist-packages/_pytest/main.py", line 315 in pytest_cmdline_main
  File "/usr/local/lib/python3.10/dist-packages/pluggy/_callers.py", line 39 in _multicall
  File "/usr/local/lib/python3.10/dist-packages/pluggy/_manager.py", line 80 in _hookexec
  File "/usr/local/lib/python3.10/dist-packages/pluggy/_hooks.py", line 265 in __call__
  File "/usr/local/lib/python3.10/dist-packages/_pytest/config/__init__.py", line 164 in main
  File "/usr/local/lib/python3.10/dist-packages/_pytest/config/__init__.py", line 187 in console_main
  File "/usr/local/lib/python3.10/dist-packages/pytest/__main__.py", line 5 in <module>
  File "/usr/lib/python3.10/runpy.py", line 86 in _run_code
  File "/usr/lib/python3.10/runpy.py", line 196 in _run_module_as_main

Extension modules: numpy.core._multiarray_umath, numpy.core._multiarray_tests, numpy.linalg._umath_linalg, numpy.fft._pocketfft_internal, numpy.random._common, numpy.random.bit_generator, numpy.random._bounded_integers, numpy.random._mt19937, numpy.random.mtrand, numpy.random._philox, numpy.random._pcg64, numpy.random._sfc64, numpy.random._generator (total: 13)
```

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
