### PR TITLE
Revert "Accept Python iterables and sequences as C++ sets and vectors"

### DIFF
--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -67,59 +67,22 @@ private:
     }
     void reserve_maybe(const anyset &, void *) {}
 
-    template <typename T = Type, enable_if_t<has_reserve_method<T>::value, int> = 0>
-    void reserve_maybe(const sequence &s, Type *) {
-        value.reserve(s.size());
-    }
-    void reserve_maybe(const sequence &, void *) {}
-
-    template <typename ContainerType>
-    bool insert_elements(const ContainerType &container, bool convert) {
-        for (auto it : container) {
+public:
+    bool load(handle src, bool convert) {
+        if (!isinstance<anyset>(src)) {
+            return false;
+        }
+        auto s = reinterpret_borrow<anyset>(src);
+        value.clear();
+        reserve_maybe(s, &value);
+        for (auto entry : s) {
             key_conv conv;
-            if (!conv.load(it, convert)) {
+            if (!conv.load(entry, convert)) {
                 return false;
             }
             value.insert(cast_op<Key &&>(std::move(conv)));
         }
         return true;
-    }
-
-public:
-    bool load(handle src, bool convert) {
-        if (isinstance<bytes>(src) || isinstance<str>(src) || isinstance<dict>(src)) {
-            return false;
-        }
-        if (isinstance<anyset>(src)) {
-            auto s = reinterpret_borrow<anyset>(src);
-            value.clear();
-            reserve_maybe(s, &value);
-            if (!insert_elements(s, convert)) {
-                return false;
-            }
-            return true;
-        }
-        if (!convert) {
-            return false;
-        }
-        if (isinstance<sequence>(src)) {
-            auto s = reinterpret_borrow<sequence>(src);
-            value.clear();
-            reserve_maybe(s, &value);
-            if (!insert_elements(s, convert)) {
-                return false;
-            }
-            return true;
-        }
-        if (isinstance<iterable>(src)) {
-            auto s = reinterpret_borrow<iterable>(src);
-            value.clear();
-            if (!insert_elements(s, convert)) {
-                return false;
-            }
-            return true;
-        }
-        return false;
     }
 
     template <typename T>
@@ -205,42 +168,13 @@ struct list_caster {
     using value_conv = make_caster<Value>;
 
     bool load(handle src, bool convert) {
-        if (isinstance<bytes>(src) || isinstance<str>(src) || isinstance<dict>(src)) {
+        if (!isinstance<sequence>(src) || isinstance<bytes>(src) || isinstance<str>(src)) {
             return false;
         }
-        if (isinstance<sequence>(src)) {
-            auto s = reinterpret_borrow<sequence>(src);
-            value.clear();
-            reserve_maybe(s, &value);
-            if (!insert_elements(s, convert)) {
-                return false;
-            }
-            return true;
-        }
-        if (!convert) {
-            return false;
-        }
-        if (isinstance<iterable>(src)) {
-            auto s = reinterpret_borrow<iterable>(src);
-            value.clear();
-            if (!insert_elements(s, convert)) {
-                return false;
-            }
-            return true;
-        }
-        return false;
-    }
-
-private:
-    template <typename T = Type, enable_if_t<has_reserve_method<T>::value, int> = 0>
-    void reserve_maybe(const sequence &s, Type *) {
-        value.reserve(s.size());
-    }
-    void reserve_maybe(const sequence &, void *) {}
-
-    template <typename ContainerType>
-    bool insert_elements(const ContainerType &container, bool convert) {
-        for (auto it : container) {
+        auto s = reinterpret_borrow<sequence>(src);
+        value.clear();
+        reserve_maybe(s, &value);
+        for (auto it : s) {
             value_conv conv;
             if (!conv.load(it, convert)) {
                 return false;
@@ -249,6 +183,13 @@ private:
         }
         return true;
     }
+
+private:
+    template <typename T = Type, enable_if_t<has_reserve_method<T>::value, int> = 0>
+    void reserve_maybe(const sequence &s, Type *) {
+        value.reserve(s.size());
+    }
+    void reserve_maybe(const sequence &, void *) {}
 
 public:
     template <typename T>

--- a/tests/test_stl.py
+++ b/tests/test_stl.py
@@ -22,14 +22,6 @@ def test_vector(doc):
     # Test regression caused by 936: pointers to stl containers weren't castable
     assert m.cast_ptr_vector() == ["lvalue", "lvalue"]
 
-    # pywrapcc: Also accept Python iterables, except bytes, strings and
-    # dictionaries, as C++ vector.
-    assert m.load_vector(set(lst))
-    assert m.load_vector(iter(lst))
-    pytest.raises(TypeError, m.load_vector, dict(zip(lst, lst)))
-    pytest.raises(TypeError, m.load_vector, "foo")
-    pytest.raises(TypeError, m.load_vector, b"foo")
-
 
 def test_deque():
     """std::deque <-> list"""
@@ -85,14 +77,6 @@ def test_set(doc):
 
     assert doc(m.cast_set) == "cast_set() -> Set[str]"
     assert doc(m.load_set) == "load_set(arg0: Set[str]) -> bool"
-
-    # pywrapcc: Also accept Python iterables, except bytes, strings and
-    # dictionaries, as C++ set.
-    assert m.load_set(list(s))
-    assert m.load_set(iter(s))
-    pytest.raises(TypeError, m.load_set, dict(zip(s, s)))
-    pytest.raises(TypeError, m.load_set, "foo")
-    pytest.raises(TypeError, m.load_set, b"foo")
 
 
 def test_recursive_casting():


### PR DESCRIPTION
Reverts google/pywrapcc#30042 because of internal test failures.

