### PR TITLE
Make stl.h `list|set|map_caster` more user friendly.

### DIFF
--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -76,7 +76,7 @@ inline bool PyObjectIsInstanceWithOneOfTpNames(PyObject *obj,
     }
     const char *obj_tp_name = Py_TYPE(obj)->tp_name;
     for (const auto *tp_name : tp_names) {
-        if (strcmp(obj_tp_name, tp_name) == 0) {
+        if (std::strcmp(obj_tp_name, tp_name) == 0) {
             return true;
         }
     }

--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -104,16 +104,13 @@ struct set_caster {
 
 private:
     template <typename T = Type, enable_if_t<has_reserve_method<T>::value, int> = 0>
-    void reserve_maybe(const sequence &s, Type *) {
+    void reserve_maybe(const anyset &s, Type *) {
         value.reserve(s.size());
     }
-    void reserve_maybe(const sequence &, void *) {}
+    void reserve_maybe(const anyset &, void *) {}
 
-    bool convert_elements(handle seq, bool convert) {
-        auto s = reinterpret_borrow<sequence>(seq);
-        value.clear();
-        reserve_maybe(s, &value);
-        for (auto it : seq) {
+    bool convert_iterable(iterable itbl, bool convert) {
+        for (auto it : itbl) {
             key_conv conv;
             if (!conv.load(it, convert)) {
                 return false;
@@ -123,23 +120,27 @@ private:
         return true;
     }
 
+    bool convert_anyset(anyset s, bool convert) {
+        value.clear();
+        reserve_maybe(s, &value);
+        return convert_iterable(s, convert);
+    }
+
 public:
     bool load(handle src, bool convert) {
         if (!PyObjectTypeIsConvertibleToStdSet(src.ptr())) {
             return false;
         }
-        if (isinstance<sequence>(src)) {
-            return convert_elements(src, convert);
+        if (isinstance<anyset>(src)) {
+            value.clear();
+            return convert_anyset(reinterpret_borrow<anyset>(src), convert);
         }
         if (!convert) {
             return false;
         }
-        // Designed to be behavior-equivalent to passing tuple(src) from Python:
-        // The conversion to a tuple will first exhaust the iterator object, to ensure that
-        // the iterator is not left in an unpredictable (to the caller) partially-consumed
-        // state.
         assert(isinstance<iterable>(src));
-        return convert_elements(tuple(reinterpret_borrow<iterable>(src)), convert);
+        value.clear();
+        return convert_iterable(reinterpret_borrow<iterable>(src), convert);
     }
 
     template <typename T>
@@ -206,7 +207,6 @@ public:
         auto items = src.attr("items")();
         assert(isinstance<iterable>(items));
         return convert_elements(dict(reinterpret_borrow<iterable>(items)), convert);
-        return false;
     }
 
     template <typename T>

--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -97,8 +97,20 @@ inline bool PyObjectTypeIsConvertibleToStdSet(PyObject *obj) {
 }
 
 inline bool PyObjectTypeIsConvertibleToStdMap(PyObject *obj) {
-    return (PyDict_Check(obj) != 0)
-           || ((PyMapping_Check(obj) != 0) && (PyObject_HasAttrString(obj, "items") != 0));
+    if (PyDict_Check(obj)) {
+        return true;
+    }
+    if (!PyMapping_Check(obj)) {
+        return false;
+    }
+    PyObject *items = PyObject_GetAttrString(obj, "items");
+    if (items == nullptr) {
+        PyErr_Clear();
+        return false;
+    }
+    bool is_convertible = (PyCallable_Check(items) != 0);
+    Py_DECREF(items);
+    return is_convertible;
 }
 
 //

--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -39,7 +39,7 @@ PYBIND11_NAMESPACE_BEGIN(detail)
 
 //
 // Begin: Equivalent of
-//        https://github.com/google/clif/blob/337b2a106c0552ad85d40cfc3797465756840ea0/clif/python/runtime.cc#L388-L424
+//        https://github.com/google/clif/blob/ae4eee1de07cdf115c0c9bf9fec9ff28efce6f6c/clif/python/runtime.cc#L388-L438
 /*
 The three `PyObjectTypeIsConvertibleTo*()` functions below are
 the result of converging the behaviors of pybind11 and PyCLIF

--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -100,7 +100,7 @@ inline bool PyObjectTypeIsConvertibleToStdMap(PyObject *obj) {
     if (PyDict_Check(obj)) {
         return true;
     }
-    if (!PyMapping_Check(obj)) {
+    if (PyMapping_Check(obj) == 0) {
         return false;
     }
     PyObject *items = PyObject_GetAttrString(obj, "items");

--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -40,7 +40,34 @@ PYBIND11_NAMESPACE_BEGIN(detail)
 //
 // Begin: Equivalent of
 //        https://github.com/google/clif/blob/337b2a106c0552ad85d40cfc3797465756840ea0/clif/python/runtime.cc#L388-L424
-//
+/*
+The three `PyObjectTypeIsConvertibleTo*()` functions below are
+the result of converging the behaviors of pybind11 and PyCLIF
+(http://github.com/google/clif).
+
+Originally PyCLIF was extremely far on the permissive side of the spectrum,
+while pybind11 was very far on the strict side. Originally PyCLIF accepted any
+Python iterable as input for a C++ `vector`/`set`/`map` argument, as long as
+the elements were convertible. The obvious (in hindsight) problem was that
+any empty Python iterable could be passed to any of these C++ types, e.g. `{}`
+was accpeted for C++ `vector`/`set` arguments, or `[]` for C++ `map` arguments.
+
+The functions below strike a practical permissive-vs-strict compromise,
+informed by tens of thousands of use cases in the wild. A main objective is
+to prevent accidents and improve readability:
+
+- Python literals must match the C++ types.
+
+- For C++ `set`: The potentially reducing conversion from a Python sequence
+  (e.g. Python `list` or `tuple`) to a C++ `set` must be explicit, by going
+  through a Python `set`.
+
+- However, a Python `set` can still be passed to a C++ `vector`. The rationale
+  is that this conversion is not reducing. Implicit conversions of this kind
+  are also fairly commonly used, therefore enforcing explicit conversions
+  would have an unfavorable cost : benefit ratio; more sloppily speaking,
+  such an enforcement would be more annyoing than helpful.
+*/
 
 inline bool PyObjectIsInstanceWithOneOfTpNames(PyObject *obj,
                                                std::initializer_list<const char *> tp_names) {

--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -327,12 +327,8 @@ private:
         return size == Size;
     }
 
-public:
-    bool load(handle src, bool convert) {
-        if (!isinstance<sequence>(src)) {
-            return false;
-        }
-        auto l = reinterpret_borrow<sequence>(src);
+    bool convert_elements(handle seq, bool convert) {
+        auto l = reinterpret_borrow<sequence>(seq);
         if (!require_size(l.size())) {
             return false;
         }
@@ -345,6 +341,25 @@ public:
             value[ctr++] = cast_op<Value &&>(std::move(conv));
         }
         return true;
+    }
+
+public:
+    bool load(handle src, bool convert) {
+        if (!PyObjectTypeIsConvertibleToStdVector(src.ptr())) {
+            return false;
+        }
+        if (isinstance<sequence>(src)) {
+            return convert_elements(src, convert);
+        }
+        if (!convert) {
+            return false;
+        }
+        // Designed to be behavior-equivalent to passing tuple(src) from Python:
+        // The conversion to a tuple will first exhaust the generator object, to ensure that
+        // the generator is not left in an unpredictable (to the caller) partially-consumed
+        // state.
+        assert(isinstance<iterable>(src));
+        return convert_elements(tuple(reinterpret_borrow<iterable>(src)), convert);
     }
 
     template <typename T>

--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -13,6 +13,7 @@
 #include "detail/common.h"
 
 #include <deque>
+#include <initializer_list>
 #include <list>
 #include <map>
 #include <ostream>
@@ -37,8 +38,8 @@ PYBIND11_NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
 PYBIND11_NAMESPACE_BEGIN(detail)
 
 //
-// Begin: Code developed under https://github.com/google/clif/blob/main/clif/python/runtime.cc
-//        (currently unpublished)
+// Begin: Equivalent of
+//        https://github.com/google/clif/blob/337b2a106c0552ad85d40cfc3797465756840ea0/clif/python/runtime.cc#L388-L424
 //
 
 inline bool PyObjectIsInstanceWithOneOfTpNames(PyObject *obj,
@@ -74,7 +75,7 @@ inline bool PyObjectTypeIsConvertibleToStdMap(PyObject *obj) {
 }
 
 //
-// End: Code developed under https://github.com/google/clif/blob/main/clif/python/runtime.cc
+// End: Equivalent of clif/python/runtime.cc
 //
 
 /// Extracts an const lvalue reference or rvalue reference for U based on the type of T (e.g. for

--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -100,6 +100,9 @@ inline bool PyObjectTypeIsConvertibleToStdMap(PyObject *obj) {
     if (PyDict_Check(obj)) {
         return true;
     }
+    // Implicit requirement in the conditions below:
+    // A type with `.__getitem__()` & `.items()` methods must implement these
+    // to be compatible with https://docs.python.org/3/c-api/mapping.html
     if (PyMapping_Check(obj) == 0) {
         return false;
     }
@@ -239,11 +242,10 @@ public:
         if (!convert) {
             return false;
         }
-        // Designed to be behavior-equivalent to passing dict(src.items()) from Python:
-        // The conversion to a dict will first exhaust the iterator object, to ensure that
-        // the iterator is not left in an unpredictable (to the caller) partially-consumed
-        // state.
-        auto items = src.attr("items")();
+        auto items = reinterpret_steal<object>(PyMapping_Items(src.ptr()));
+        if (!items) {
+            throw error_already_set();
+        }
         assert(isinstance<iterable>(items));
         return convert_elements(dict(reinterpret_borrow<iterable>(items)), convert);
     }

--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -109,7 +109,7 @@ private:
     }
     void reserve_maybe(const anyset &, void *) {}
 
-    bool convert_iterable(iterable itbl, bool convert) {
+    bool convert_iterable(const iterable &itbl, bool convert) {
         for (auto it : itbl) {
             key_conv conv;
             if (!conv.load(it, convert)) {

--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -66,7 +66,7 @@ to prevent accidents and improve readability:
   is that this conversion is not reducing. Implicit conversions of this kind
   are also fairly commonly used, therefore enforcing explicit conversions
   would have an unfavorable cost : benefit ratio; more sloppily speaking,
-  such an enforcement would be more annyoing than helpful.
+  such an enforcement would be more annoying than helpful.
 */
 
 inline bool PyObjectIsInstanceWithOneOfTpNames(PyObject *obj,

--- a/tests/test_stl.cpp
+++ b/tests/test_stl.cpp
@@ -167,6 +167,14 @@ struct type_caster<ReferenceSensitiveOptional<T>>
 } // namespace detail
 } // namespace PYBIND11_NAMESPACE
 
+int pass_std_vector_int(const std::vector<int> &v) {
+    int zum = 100;
+    for (const int i : v) {
+        zum += 2 * i;
+    }
+    return zum;
+}
+
 TEST_SUBMODULE(stl, m) {
     // test_vector
     m.def("cast_vector", []() { return std::vector<int>{1}; });
@@ -549,14 +557,31 @@ TEST_SUBMODULE(stl, m) {
         // Without explicitly specifying `take_ownership`, this function leaks.
         py::return_value_policy::take_ownership);
 
-    m.def("pass_std_vector_int", [](const std::vector<int> &vec_int) { return vec_int.size(); });
-    m.def("pass_std_vector_pair_int", [](const std::vector<std::pair<int, int>> &vec_pair_int) {
-        return vec_pair_int.size();
+    m.def("pass_std_vector_int", pass_std_vector_int);
+    m.def("pass_std_vector_pair_int", [](const std::vector<std::pair<int, int>> &v) {
+        int zum = 0;
+        for (const auto &ij : v) {
+            zum += ij.first * 100 + ij.second;
+        }
+        return zum;
     });
-    m.def("pass_std_array_int_2",
-          [](const std::array<int, 2> &arr_int) { return arr_int.size(); });
-    m.def("pass_std_set_int", [](const std::set<int> &set_int) { return set_int.size(); });
-    m.def("pass_std_map_int", [](const std::map<int, int> &map_int) { return map_int.size(); });
+    m.def("pass_std_array_int_2", [](const std::array<int, 2> &a) {
+        return pass_std_vector_int(std::vector<int>(a.begin(), a.end())) + 1;
+    });
+    m.def("pass_std_set_int", [](const std::set<int> &s) {
+        int zum = 200;
+        for (const int i : s) {
+            zum += 3 * i;
+        }
+        return zum;
+    });
+    m.def("pass_std_map_int", [](const std::map<int, int> &m) {
+        int zum = 500;
+        for (const auto &p : m) {
+            zum += p.first * 1000 + p.second;
+        }
+        return zum;
+    });
 
     // test return_value_policy::_return_as_bytes
     m.def(

--- a/tests/test_stl.cpp
+++ b/tests/test_stl.cpp
@@ -553,6 +553,8 @@ TEST_SUBMODULE(stl, m) {
     m.def("pass_std_vector_pair_int", [](const std::vector<std::pair<int, int>> &vec_pair_int) {
         return vec_pair_int.size();
     });
+    m.def("pass_std_array_int_2",
+          [](const std::array<int, 2> &arr_int) { return arr_int.size(); });
     m.def("pass_std_set_int", [](const std::set<int> &set_int) { return set_int.size(); });
     m.def("pass_std_map_int", [](const std::map<int, int> &map_int) { return map_int.size(); });
 

--- a/tests/test_stl.cpp
+++ b/tests/test_stl.cpp
@@ -549,6 +549,13 @@ TEST_SUBMODULE(stl, m) {
         // Without explicitly specifying `take_ownership`, this function leaks.
         py::return_value_policy::take_ownership);
 
+    m.def("pass_std_vector_int", [](const std::vector<int> &vec_int) { return vec_int.size(); });
+    m.def("pass_std_vector_pair_int", [](const std::vector<std::pair<int, int>> &vec_pair_int) {
+        return vec_pair_int.size();
+    });
+    m.def("pass_std_set_int", [](const std::set<int> &set_int) { return set_int.size(); });
+    m.def("pass_std_map_int", [](const std::map<int, int> &map_int) { return map_int.size(); });
+
     // test return_value_policy::_return_as_bytes
     m.def(
         "invalid_utf8_string_array_as_bytes",

--- a/tests/test_stl.py
+++ b/tests/test_stl.py
@@ -454,6 +454,17 @@ class FakePyMappingBadItems(FakePyMappingMissingItems):
         return ((1, 2), (3, "x"))
 
 
+class FakePyMappingItemsNotCallable(FakePyMappingMissingItems):
+    @property
+    def items(self):
+        return ((1, 2), (3, 4))
+
+
+class FakePyMappingItemsWithArg(FakePyMappingMissingItems):
+    def items(self, _):
+        return ((1, 2), (3, 4))
+
+
 class FakePyMappingGenObj(FakePyMappingMissingItems):
     def __init__(self, gen_obj):
         super().__init__()
@@ -466,13 +477,17 @@ class FakePyMappingGenObj(FakePyMappingMissingItems):
 def test_pass_std_map_int():
     fn = m.pass_std_map_int
     assert fn({1: 2, 3: 4}) == 4506
+    with pytest.raises(TypeError):
+        fn([])
     assert fn(FakePyMappingWithItems()) == 3507
     with pytest.raises(TypeError):
         fn(FakePyMappingMissingItems())
     with pytest.raises(TypeError):
         fn(FakePyMappingBadItems())
     with pytest.raises(TypeError):
-        fn([])
+        fn(FakePyMappingItemsNotCallable())
+    with pytest.raises(TypeError):
+        fn(FakePyMappingItemsWithArg())
 
 
 @pytest.mark.parametrize(

--- a/tests/test_stl.py
+++ b/tests/test_stl.py
@@ -404,10 +404,10 @@ def test_pass_std_vector_pair_int():
 
 
 def test_list_caster_fully_consumes_generator_object():
-    def gen_mix():
+    def gen_invalid():
         yield from [1, 2.0, 3]
 
-    gen_obj = gen_mix()
+    gen_obj = gen_invalid()
     with pytest.raises(TypeError):
         m.pass_std_vector_int(gen_obj)
     assert not tuple(gen_obj)
@@ -483,10 +483,10 @@ def test_pass_std_map_int():
     ],
 )
 def test_map_caster_fully_consumes_generator_object(items, expected_exception):
-    def gen_mix():
+    def gen_invalid():
         yield from items
 
-    gen_obj = gen_mix()
+    gen_obj = gen_invalid()
     with pytest.raises(expected_exception):
         m.pass_std_map_int(FakePyMappingGenObj(gen_obj))
     assert not tuple(gen_obj)

--- a/tests/test_stl.py
+++ b/tests/test_stl.py
@@ -378,15 +378,17 @@ def test_return_vector_bool_raw_ptr():
     assert len(v) == 4513
 
 
-def test_pass_std_vector_int():
-    fn = m.pass_std_vector_int
+@pytest.mark.parametrize("fn", [m.pass_std_vector_int, m.pass_std_array_int_2])
+def test_pass_std_vector_int(fn):
     assert fn([1, 2]) == 2
     assert fn((1, 2)) == 2
     assert fn({1, 2}) == 2
     assert fn({"x": 1, "y": 2}.values()) == 2
     assert fn({1: None, 2: None}.keys()) == 2
-    assert fn(i for i in range(3)) == 3
-    assert fn(map(lambda i: i, range(4))) == 4  # noqa: C417
+    assert fn(i for i in range(2)) == 2
+    assert fn(map(lambda i: i, range(2))) == 2  # noqa: C417
+    with pytest.raises(TypeError):
+        fn({1: 2, 3: 4})
     with pytest.raises(TypeError):
         fn({})
 

--- a/tests/test_stl.py
+++ b/tests/test_stl.py
@@ -381,39 +381,26 @@ def test_return_vector_bool_raw_ptr():
     assert len(v) == 4513
 
 
-@pytest.mark.parametrize("fn", [m.pass_std_vector_int, m.pass_std_array_int_2])
-def test_pass_std_vector_int(fn):
-    assert fn([1, 2]) == 2
-    assert fn((1, 2)) == 2
-    assert fn({1, 2}) == 2
-    assert fn({"x": 1, "y": 2}.values()) == 2
-    assert fn({1: None, 2: None}.keys()) == 2
-    assert fn(i for i in range(2)) == 2
-    assert fn(map(lambda i: i, range(2))) == 2  # noqa: C417
+@pytest.mark.parametrize(
+    ("fn", "offset"), [(m.pass_std_vector_int, 0), (m.pass_std_array_int_2, 1)]
+)
+def test_pass_std_vector_int(fn, offset):
+    assert fn([7, 13]) == 140 + offset
+    assert fn({6, 2}) == 116 + offset
+    assert fn({"x": 8, "y": 11}.values()) == 138 + offset
+    assert fn({3: None, 9: None}.keys()) == 124 + offset
+    assert fn(i for i in [4, 17]) == 142 + offset
+    assert fn(map(lambda i: i * 3, [8, 7])) == 190 + offset  # noqa: C417
     with pytest.raises(TypeError):
-        fn({1: 2, 3: 4})
+        fn({"x": 0, "y": 1})
     with pytest.raises(TypeError):
         fn({})
 
 
 def test_pass_std_vector_pair_int():
     fn = m.pass_std_vector_pair_int
-    assert fn({1: 2, 3: 4}.items()) == 2
-    assert fn(zip([1, 2], [3, 4])) == 2
-
-
-def test_pass_std_set_int():
-    fn = m.pass_std_set_int
-    assert fn({1, 2}) == 2
-    assert fn({1: None, 2: None}.keys()) == 2
-    with pytest.raises(TypeError):
-        fn([1, 2])
-    with pytest.raises(TypeError):
-        fn((1, 2))
-    with pytest.raises(TypeError):
-        fn({})
-    with pytest.raises(TypeError):
-        fn(i for i in range(3))
+    assert fn({1: 2, 3: 4}.items()) == 406
+    assert fn(zip([5, 17], [13, 9])) == 2222
 
 
 def test_list_caster_fully_consumes_generator_object():
@@ -426,6 +413,32 @@ def test_list_caster_fully_consumes_generator_object():
     assert not tuple(gen_obj)
 
 
+def test_pass_std_set_int():
+    fn = m.pass_std_set_int
+    assert fn({3, 15}) == 254
+    assert fn({5: None, 12: None}.keys()) == 251
+    with pytest.raises(TypeError):
+        fn([])
+    with pytest.raises(TypeError):
+        fn({})
+    with pytest.raises(TypeError):
+        fn({}.values())
+    with pytest.raises(TypeError):
+        fn(i for i in [])
+
+
+def test_set_caster_dict_keys_failure():
+    dict_keys = {1: None, 2.0: None, 3: None}.keys()
+    # The asserts does not really exercise anything in pybind11, but if one of
+    # them fails in some future version of Python, the set_caster load
+    # implementation may need to be revisited.
+    assert tuple(dict_keys) == (1, 2.0, 3)
+    assert tuple(dict_keys) == (1, 2.0, 3)
+    with pytest.raises(TypeError):
+        m.pass_std_set_int(dict_keys)
+    assert tuple(dict_keys) == (1, 2.0, 3)
+
+
 class FakePyMappingMissingItems:
     def __getitem__(self, _):
         raise RuntimeError("Not expected to be called.")
@@ -433,7 +446,7 @@ class FakePyMappingMissingItems:
 
 class FakePyMappingWithItems(FakePyMappingMissingItems):
     def items(self):
-        return ((1, 2), (3, 4))
+        return ((1, 3), (2, 4))
 
 
 class FakePyMappingBadItems(FakePyMappingMissingItems):
@@ -441,10 +454,19 @@ class FakePyMappingBadItems(FakePyMappingMissingItems):
         return ((1, 2), (3, "x"))
 
 
+class FakePyMappingGenObj(FakePyMappingMissingItems):
+    def __init__(self, gen_obj):
+        super().__init__()
+        self.gen_obj = gen_obj
+
+    def items(self):
+        yield from self.gen_obj
+
+
 def test_pass_std_map_int():
     fn = m.pass_std_map_int
-    assert fn({1: 2, 3: 4}) == 2
-    assert fn(FakePyMappingWithItems()) == 2
+    assert fn({1: 2, 3: 4}) == 4506
+    assert fn(FakePyMappingWithItems()) == 3507
     with pytest.raises(TypeError):
         fn(FakePyMappingMissingItems())
     with pytest.raises(TypeError):
@@ -453,8 +475,21 @@ def test_pass_std_map_int():
         fn([])
 
 
-# TODO(rwgk): test_set_caster_fully_consumes_iterator_object
-# TODO(rwgk): test_map_caster_fully_consumes_iterator_object
+@pytest.mark.parametrize(
+    ("items", "expected_exception"),
+    [
+        (((1, 2), (3, "x"), (4, 5)), TypeError),
+        (((1, 2), (3, 4, 5), (6, 7)), ValueError),
+    ],
+)
+def test_map_caster_fully_consumes_generator_object(items, expected_exception):
+    def gen_mix():
+        yield from items
+
+    gen_obj = gen_mix()
+    with pytest.raises(expected_exception):
+        m.pass_std_map_int(FakePyMappingGenObj(gen_obj))
+    assert not tuple(gen_obj)
 
 
 def test_return_as_bytes_policy():


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
pybind/pybind11#4686 applied to pywrapcc.

Snapshot of the pybind/pybind11 PR description as of 2023-07-17 14:27 PDT:

With this PR, it is no longer necessary to explicitly convert Python iterables to `tuple()`, `set()`, or `map()` in several common situations, for example:

```diff
-    fn(tuple({"x": 8, "y": 11}.values()))
+    fn({"x": 8, "y": 11}.values())

-    fn(set({5: None, 12: None}.keys()))
+    fn({5: None, 12: None}.keys())

-    fn(dict(PyMappingWithItems().items()))
+    fn(PyMappingWithItems())
```
See https://github.com/pybind/pybind11/pull/4686#issuecomment-1636838113 below for a more complete demonstration of the behavior differences. (Note that the diff in that comment is reversed, what is `+` here is `-` there and vice versa.)

This PR strikes a careful compromise between being user friendly and being safe. This compromise was informed by 10s of thousands of use cases in the wild (Google codebase, which includes a very large number of open source third-party packages). Concretely, in connection with PyCLIF-pybind11 integration work, the behaviors of PyCLIF (http://github.com/google/clif) and pybind11 needed to be converged. Originally PyCLIF was extremely far on the permissive side of the spectrum, by accepting any Python iterable as input for a C++ `vector`/`set`/`map` argument, as long as the elements were convertible. The obvious (in hindsight) problem was that any empty Python iterable could be passed to any of these C++ types, e.g. `{}` was accpeted for C++ `vector`/`set` arguments, or `[]` for C++ `map` arguments. To fix this, the code base was cleaned up, and gating functions were added to enforce the desired behavior:

* https://github.com/google/clif/blob/ae4eee1de07cdf115c0c9bf9fec9ff28efce6f6c/clif/python/runtime.cc#L388-L438

The exact same gating functions are adopted here. Without this behavior change in pybind11, it would be necessary to insert a very large number of explicit `tuple()`, `set()`, `map()` conversions in the Google codebase, to complete the PyCLIF-pybind11 integration work. While it is very easy to tell new users to pass e.g. `tuple(iterable)` instead of `iterable`, it is not easy to convince hundreds of happy existing PyCLIF users to accept retroactively inserting the explicit conversions. The obvious question that will come back: Why do we have to clutter our code like this? There is no good reason. The exact implementation of the gating functions may seem a little arbitrary at first sight, but is in fact informed by what amounts to a large-scale field experiment, with the originally very permissive behavior of PyCLIF.

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
