### PR TITLE
Enforce correct return_value_policy_pack for stl containers

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1171,6 +1171,7 @@ struct return_value_policy_override<
     static return_value_policy policy(return_value_policy p) {
         return !std::is_lvalue_reference<Return>::value && !std::is_pointer<Return>::value
                        && p != return_value_policy::_clif_automatic
+                       && p != return_value_policy::_return_as_bytes
                    ? return_value_policy::move
                    : p;
     }

--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -187,9 +187,9 @@ public:
 
     template <typename T>
     static handle cast(T &&src, const return_value_policy_pack &rvpp, handle parent) {
-        return_value_policy_pack rvpp_local = rvpp;
+        return_value_policy_pack rvpp_local = rvpp.get(0);
         if (!std::is_lvalue_reference<T>::value) {
-            rvpp_local = rvpp.override_policy(return_value_policy_override<Key>::policy);
+            rvpp_local = rvpp_local.override_policy(return_value_policy_override<Key>::policy);
         }
         pybind11::set s;
         for (auto &&value : src) {
@@ -323,9 +323,9 @@ private:
 public:
     template <typename T>
     static handle cast(T &&src, const return_value_policy_pack &rvpp, handle parent) {
-        return_value_policy_pack rvpp_local = rvpp;
+        return_value_policy_pack rvpp_local = rvpp.get(0);
         if (!std::is_lvalue_reference<T>::value) {
-            rvpp_local = rvpp.override_policy(return_value_policy_override<Value>::policy);
+            rvpp_local = rvpp_local.override_policy(return_value_policy_override<Value>::policy);
         }
         list l(src.size());
         ssize_t index = 0;
@@ -406,11 +406,12 @@ public:
 
     template <typename T>
     static handle cast(T &&src, const return_value_policy_pack &rvpp, handle parent) {
+        return_value_policy_pack rvpp_local = rvpp.get(0);
         list l(src.size());
         ssize_t index = 0;
         for (auto &&value : src) {
             auto value_ = reinterpret_steal<object>(
-                value_conv::cast(detail::forward_like<T>(value), rvpp, parent));
+                value_conv::cast(detail::forward_like<T>(value), rvpp_local, parent));
             if (!value_) {
                 return handle();
             }
@@ -461,9 +462,9 @@ struct optional_caster {
         if (!src) {
             return none().release();
         }
-        return_value_policy_pack rvpp_local = rvpp;
+        return_value_policy_pack rvpp_local = rvpp.get(0);
         if (!std::is_lvalue_reference<T>::value) {
-            rvpp_local = rvpp.override_policy(return_value_policy_override<Value>::policy);
+            rvpp_local = rvpp_local.override_policy(return_value_policy_override<Value>::policy);
         }
         // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
         return value_conv::cast(*std::forward<T>(src), rvpp_local, parent);

--- a/tests/test_return_value_policy_pack.cpp
+++ b/tests/test_return_value_policy_pack.cpp
@@ -311,7 +311,7 @@ TEST_SUBMODULE(return_value_policy_pack, m) {
     m.def(
         "return_set_sb",
         []() { return return_set_pair_string(); },
-        py::return_value_policy_pack({rvpc, rvpb}));
+        py::return_value_policy_pack({{rvpc, rvpb}}));
     m.def(
         "return_set_bs",
         []() {
@@ -319,12 +319,12 @@ TEST_SUBMODULE(return_value_policy_pack, m) {
             static auto *s = new SetPairString(return_set_pair_string());
             return s;
         },
-        py::return_value_policy_pack({rvpb, rvpc}));
+        py::return_value_policy_pack({{rvpb, rvpc}}));
 
     m.def(
         "return_vector_sb",
         []() { return return_vector_pair_string(); },
-        py::return_value_policy_pack({rvpc, rvpb}));
+        py::return_value_policy_pack({{rvpc, rvpb}}));
     m.def(
         "return_vector_bs",
         []() {
@@ -332,12 +332,12 @@ TEST_SUBMODULE(return_value_policy_pack, m) {
             static auto *v = new VectorPairString(return_vector_pair_string());
             return v;
         },
-        py::return_value_policy_pack({rvpb, rvpc}));
+        py::return_value_policy_pack({{rvpb, rvpc}}));
 
     m.def(
         "return_array_sb",
         []() { return return_array_pair_string(); },
-        py::return_value_policy_pack({rvpc, rvpb}));
+        py::return_value_policy_pack({{rvpc, rvpb}}));
     m.def(
         "return_array_bs",
         []() {
@@ -345,7 +345,7 @@ TEST_SUBMODULE(return_value_policy_pack, m) {
             static auto *a = new ArrayPairString(return_array_pair_string());
             return a;
         },
-        py::return_value_policy_pack({rvpb, rvpc}));
+        py::return_value_policy_pack({{rvpb, rvpc}}));
 
     m.attr("PYBIND11_HAS_OPTIONAL") =
 #if !defined(PYBIND11_HAS_OPTIONAL)
@@ -355,7 +355,7 @@ TEST_SUBMODULE(return_value_policy_pack, m) {
     m.def(
         "return_optional_sb",
         []() { return return_optional_pair_string(); },
-        py::return_value_policy_pack({rvpc, rvpb}));
+        py::return_value_policy_pack({{rvpc, rvpb}}));
     m.def(
         "return_optional_bs",
         []() {
@@ -363,7 +363,7 @@ TEST_SUBMODULE(return_value_policy_pack, m) {
             static auto *o = new OptionalPairString(return_optional_pair_string());
             return o;
         },
-        py::return_value_policy_pack({rvpb, rvpc}));
+        py::return_value_policy_pack({{rvpb, rvpc}}));
 #endif
 
     m.attr("PYBIND11_HAS_VARIANT") =


### PR DESCRIPTION
## Description

For nested types with only one inner type and unested types, currently we can apply the same return_value_policy_pack to them. For example, for `std::vector<std::string>`, we should apply `return_value_policy_pack({_return_as_bytes})`, and for `std::string`, we should apply `return_value_policy_pack(_return_as_bytes)`. But currently we use `return_value_policy_pack(_return_as_bytes)` for both of them.

This PR is for legacy CLIF compatibility. Legacy CLIF has a `PostConv` object, which is very similar with `return_value_policy_pack`. We want `PostConv` and `return_value_policy_pack` to be one to one match. Without this PR, one `return_value_policy_pack` object can be matched with multiple `PostConv` object.