### PR TITLE
Make type caster of `std::unique_ptr` accept `return_value_policy::automatic_reference`

### DIFF
--- a/include/pybind11/detail/smart_holder_type_casters.h
+++ b/include/pybind11/detail/smart_holder_type_casters.h
@@ -965,6 +965,7 @@ struct smart_holder_type_caster<std::unique_ptr<T, D>> : smart_holder_type_caste
 
     static handle cast(std::unique_ptr<T, D> &&src, return_value_policy policy, handle parent) {
         if (policy != return_value_policy::automatic
+            && policy != return_value_policy::automatic_reference
             && policy != return_value_policy::reference_internal
             && policy != return_value_policy::move
             && policy != return_value_policy::_clif_automatic) {


### PR DESCRIPTION
## Description

Pybind11 always override `return_value_policy::automatic` and `return_value_policy::automatic_reference` with `return_value_policy::move` for `std::unique_ptr`: https://github.com/google/pywrapcc/blob/8bcd157442a1e02bb0bc06515e938bbb5f487564/include/pybind11/cast.h#L1277, so `return_value_policy::automatic` and `return_value_policy::automatic_reference` does not make any difference for `std::unique_ptr`. We should make the type caster accept both.
