### PR TITLE
Enable `"factory sets error and returns nullptr"`

### DIFF
--- a/include/pybind11/detail/init.h
+++ b/include/pybind11/detail/init.h
@@ -39,6 +39,9 @@ PYBIND11_NAMESPACE_BEGIN(initimpl)
 
 inline void no_nullptr(void *ptr) {
     if (!ptr) {
+        if (PyErr_Occurred()) {
+            throw error_already_set();
+        }
         throw type_error("pybind11::init(): factory function returned nullptr");
     }
 }

--- a/tests/test_factory_constructors.cpp
+++ b/tests/test_factory_constructors.cpp
@@ -419,6 +419,16 @@ TEST_SUBMODULE(factory_constructors, m) {
             "__init__", [](NoisyAlloc &a, int i, const std::string &) { new (&a) NoisyAlloc(i); });
     });
 
+    struct FactoryErrorAlreadySet {};
+    py::class_<FactoryErrorAlreadySet>(m, "FactoryErrorAlreadySet")
+        .def(py::init([](bool set_error) -> FactoryErrorAlreadySet * {
+            if (!set_error) {
+                return new FactoryErrorAlreadySet();
+            }
+            py::set_error(PyExc_ValueError, "factory sets error and returns nullptr");
+            return nullptr;
+        }));
+
     // static_assert testing (the following def's should all fail with appropriate compilation
     // errors):
 #if 0

--- a/tests/test_factory_constructors.py
+++ b/tests/test_factory_constructors.py
@@ -515,3 +515,10 @@ def test_invalid_self():
             str(excinfo.value)
             == "__init__(self, ...) called with invalid or missing `self` argument"
         )
+
+
+def test_factory_error_already_set():
+    obj = m.FactoryErrorAlreadySet(False)
+    assert isinstance(obj, m.FactoryErrorAlreadySet)
+    with pytest.raises(ValueError, match="factory sets error and returns nullptr"):
+        m.FactoryErrorAlreadySet(True)


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
This is a very simple change in support of the PyCLIF-pybind11 integration work:

Merely an extra `if` to pre-empt `TypeError: pybind11::init(): factory function returned nullptr`. This allows the factory function to set a custom Python error instead.

Manually written factory functions could `throw error_already_set()` directly, but in the context of PyCLIF that is very difficult (compared to this very simple PR), because the factory function can be completely unaware of pybind11.

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
