### PR TITLE
Fix minor oversight in pywrapcc#30088 (test code only).

### DIFF
--- a/tests/test_class_release_gil_before_calling_cpp_dtor.cpp
+++ b/tests/test_class_release_gil_before_calling_cpp_dtor.cpp
@@ -41,11 +41,13 @@ TEST_SUBMODULE(class_release_gil_before_calling_cpp_dtor, m) {
     py::class_<ProbeType<1>>(m, "ProbeType1", py::release_gil_before_calling_cpp_dtor())
         .def(py::init<std::string>());
 
-    m.def("GetPyGILState_Check_Result", [](const std::string &unique_key) -> std::string {
+    m.def("PopPyGILState_Check_Result", [](const std::string &unique_key) -> std::string {
         RegistryType &reg = PyGILState_Check_Results();
         if (reg.count(unique_key) == 0) {
             return "MISSING";
         }
-        return std::to_string(reg[unique_key]);
+        int res = reg[unique_key];
+        reg.erase(unique_key);
+        return std::to_string(res);
     });
 }

--- a/tests/test_class_release_gil_before_calling_cpp_dtor.py
+++ b/tests/test_class_release_gil_before_calling_cpp_dtor.py
@@ -15,5 +15,5 @@ from pybind11_tests import class_release_gil_before_calling_cpp_dtor as m
 def test_gil_state_check_results(probe_type, unique_key, expected_result):
     probe_type(unique_key)
     gc.collect()
-    result = m.GetPyGILState_Check_Result(unique_key)
+    result = m.PopPyGILState_Check_Result(unique_key)
     assert result == expected_result


### PR DESCRIPTION

<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
This is to enable running the test multiple times (e.g. for leak checking), or for compatibility with options such as `--runs_per_test`.

This PR makes the pybind11 test similar to the corresponding PyCLIF test:

* https://github.com/google/clif/blob/e0f4bf60933973b98ddb971750a9929348f84bc2/clif/testing/class_release_gil_before_calling_cpp_dtor.h#L51-L59

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
