### PR TITLE
Follow-on to google/pywrapcc#30093 (correction)

### DIFF
--- a/include/pybind11/detail/smart_holder_type_casters.h
+++ b/include/pybind11/detail/smart_holder_type_casters.h
@@ -757,7 +757,7 @@ struct smart_holder_type_caster : smart_holder_type_caster_load<T>,
             || policy == return_value_policy::_clif_automatic) {
             policy = return_value_policy::copy;
         }
-        return cast(&src, policy, parent);
+        return cast(std::addressof(src), policy, parent);
         // type_caster_base END
     }
 

--- a/include/pybind11/detail/type_caster_base.h
+++ b/include/pybind11/detail/type_caster_base.h
@@ -1116,7 +1116,7 @@ public:
             || policy == return_value_policy::automatic_reference) {
             policy = return_value_policy::copy;
         }
-        return cast(&src, policy, parent);
+        return cast(std::addressof(src), policy, parent);
     }
 
     static handle cast(itype &&src, return_value_policy, handle parent) {

--- a/tests/pybind11_tests.h
+++ b/tests/pybind11_tests.h
@@ -57,7 +57,9 @@ union IntFloat {
 class UnusualOpRef {
 public:
     using NonTrivialType = std::shared_ptr<int>; // Almost any non-trivial type will do.
-    NonTrivialType operator&() { return non_trivial_member; } // UNUSUAL operator.
+    // UNUSUAL operators:
+    NonTrivialType operator&() { return non_trivial_member; }
+    const NonTrivialType operator&() const { return non_trivial_member; }
 
 private:
     NonTrivialType non_trivial_member;

--- a/tests/pybind11_tests.h
+++ b/tests/pybind11_tests.h
@@ -57,7 +57,7 @@ union IntFloat {
 class UnusualOpRef {
 public:
     using NonTrivialType = std::shared_ptr<int>; // Almost any non-trivial type will do.
-    // UNUSUAL operators:
+    // Overriding operator& should not break pybind11.
     NonTrivialType operator&() { return non_trivial_member; }
     const NonTrivialType operator&() const { return non_trivial_member; }
 


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
Bring back `std::addressof(src)` incorrectly removed with commit https://github.com/google/pywrapcc/pull/30093/commits/bcc40b291cc073af22f0ae4e4e2da055efa303db (google/pywrapcc#30093).

This fixes an oversight in google/pywrapcc#30093: the `operator&() const` overload was missing in the test code.

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
