### PR TITLE
Fix merge accident: Equivalent of pybind/pybind11#5026 applied to pybind11/detail/abi_platform_id.h

### DIFF
--- a/include/pybind11/detail/abi_platform_id.h
+++ b/include/pybind11/detail/abi_platform_id.h
@@ -71,9 +71,9 @@
 /// Classic / Conservative / Progressive cross-module compatibility
 #ifndef PYBIND11_INTERNALS_SH_DEF
 #    if defined(PYBIND11_USE_SMART_HOLDER_AS_DEFAULT)
-#        define PYBIND11_INTERNALS_SH_DEF ""
-#    else
 #        define PYBIND11_INTERNALS_SH_DEF "_sh_def"
+#    else
+#        define PYBIND11_INTERNALS_SH_DEF ""
 #    endif
 #endif
 


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
Fix oversight in google/pywrapcc#30102. (This change is equivalent to pybind/pybind11#5026.)

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
